### PR TITLE
Add VLSP: Video-Latent Source Prior for the action flow source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ model/checkpoints
 eval/*/results
 nohup.out
 uv.lock
+.DS_Store
 
 __pycache__/
 .venv/

--- a/VLSP.md
+++ b/VLSP.md
@@ -480,5 +480,19 @@ a bonus.
   (GT-video) — generated video is what inference actually uses, so this is where the
   train/inference gap shows up.
 - Standing monitors: `success_rate`, validation action MSE, `source/source_vs_x0_mse`,
-  `source/source_vs_gaussian_mse`, `source/std_mean`, `loss/source_kl`.
+  `source/source_vs_gaussian_mse`, `source/std_mean`, `source/mu_batch_std`,
+  `source/logstd_floor_frac`, `probe/sampled_action_mse_gtvid`, `loss/source_kl`.
 - Honor the **go/no-go gates** — if a phase is unhealthy, go back; don't pile on runs.
+
+## 12. Run log
+
+- **Run 1 (2026-07, LIBERO-goal, B & C with kl=0) — FAILED: fixed
+  task-independent actions.** Root cause: source-prior **variance collapse**
+  (logstd pinned at the −5 floor ⇒ Dirac source) with a suspected
+  input-independent mu; the early "10× faster loss" was this collapse, not
+  learning. Full evidence, three pre-retraining diagnostics
+  (`scripts/vlsp_probe_prior.py`), the Run-2 plan (R1 `vlsp_r1_kl_1e3` /
+  R2 `vlsp_r2_blend_050` / R3 `vlsp_r3_kl_dropout_020`), in-training gates and
+  the new collapse metrics are documented in
+  **[VLSP_RUN1_ANALYSIS.md](VLSP_RUN1_ANALYSIS.md)** — read it before launching
+  any new VLSP run.

--- a/VLSP.md
+++ b/VLSP.md
@@ -1,0 +1,307 @@
+# VLSP: Video-Latent Source Prior for Action Flow
+
+## 1. Method summary
+
+mimic-video generates actions with a flow-matching action decoder. The partially
+denoised video-model latent is used as a **cross-attention condition** for the
+action DiT. The action flow is integrated from a Gaussian **source** endpoint:
+
+```python
+source   = torch.randn_like(action)        # N(0, I)
+x_t      = (1 - t) * action + t * source
+target_v = source - action
+pred_v   = action_dit(x_t, t, cond=video_latents, obs, ...)
+```
+
+**VLSP** keeps the video latent as a condition *and additionally* uses it to
+parameterize the **source** of the flow:
+
+```python
+video_latents      = partial_video_world_model(...)
+source, metrics    = source_prior(video_latents, obs, context_timestep, ...)
+x_t                = (1 - t) * action + t * source
+target_v           = source - action
+pred_v             = action_dit(x_t, t, cond=<normal | zero | shuffled>)
+```
+
+> **Existing mimic-video uses video latents as a *condition*.
+> VLSP uses video latents to *initialize* the action generative process.**
+
+The source-prior input and the action-decoder condition are **independently
+configurable**, which is what enables the source-only / shuffled / blended
+ablations below.
+
+When `action_source_prior.enabled = False` the code path is **bit-identical** to
+the original implementation (verified for both the training epsilon draw and the
+inference `arch_invariant_rand(seed=...)` draw).
+
+## 2. Equations
+
+```
+h_v        = W_video(o, l, sigma_v)                         # partially denoised video latent
+q_phi(s|.) = N( mu_phi(h_v, o, sigma_v), diag(sigma_phi(h_v, ...)^2) )
+
+x_t        = (1 - t) * a + t * s
+u_t        = s - a
+L_flow     = || v_theta(x_t, t, c) - u_t ||^2
+L          = L_flow + lambda_KL * KL( q_phi || N(0, I) )
+
+KL         = 0.5 * ( mu^2 + sigma^2 - 1 - log sigma^2 )     # diagonal Gaussian
+```
+
+The source `s` (and therefore `mu`, `sigma`) live in the **normalized action
+space**, because the flow loss is computed on normalized actions. The final
+prediction is unnormalized by the existing action unnormalizer.
+
+## 3. Source modes
+
+`action_source_prior.mode`:
+
+| mode                    | source `s`                                                    | uses prior net | deterministic |
+|-------------------------|--------------------------------------------------------------|:--------------:|:-------------:|
+| `gaussian`              | `randn` (baseline; inference uses `arch_invariant_rand`)      | no             | given seed    |
+| `video_prior_sample`    | `mu + T * exp(logstd) * eps`                                  | yes            | given seed    |
+| `video_prior_mean`      | `mu`                                                          | yes            | yes           |
+| `video_prior_residual`  | `eps + residual_scale * mu`                                   | yes            | given seed    |
+| `video_prior_blend`     | `alpha * s_video + sqrt(1 - alpha^2) * eps`                   | yes            | given seed    |
+| `video_prior_dropout`   | per-sample `mask * s_video + (1 - mask) * eps`               | yes            | given seed    |
+| `shuffled_video_prior`  | like `video_prior_sample` with video latents batch-shuffled  | yes            | given seed    |
+| `gt_action_noisy_debug` | `x0 + debug_noise_std * randn` (training/debug only)         | no             | no            |
+
+`action_conditioning.mode` (independent of the source):
+
+| mode             | video latent fed to the action DiT                  |
+|------------------|-----------------------------------------------------|
+| `normal`         | pass-through (baseline)                              |
+| `zero_video`     | zeros (source-only experiments)                     |
+| `shuffled_video` | shuffled across the batch (negative control)        |
+| `dropout_video`  | per-sample random zeroing with prob `dropout_prob`  |
+
+## 4. Config options
+
+`cosmos_predict2/configs/config_world2action.py`:
+
+```python
+@attrs.define
+class ActionSourcePriorConfig:
+    enabled: bool = False               # master switch (False => exact baseline)
+    mode: str = "gaussian"
+
+    pool_type: str = "mean"             # mean | attention | perceiver
+    hidden_dim: int = 1024
+    num_perceiver_latents: int = 8
+    num_attention_heads: int = 8
+    mlp_depth: int = 2
+
+    logstd_min: float = -5.0
+    logstd_max: float = 1.0
+    init_logstd: float = -1.0
+
+    residual_scale: float = 1.0         # video_prior_residual
+    blend_alpha: float = 1.0            # video_prior_blend
+    source_dropout_prob: float = 0.0    # video_prior_dropout
+    dropout_granularity: str = "sample" # sample | trajectory | element
+    sampling_temperature: float = 1.0   # scales the stochastic term
+
+    detach_video_latents: bool = True
+    use_state: bool = True
+    use_context_timestep: bool = True
+    use_language: bool = False          # off by default (not plumbed to inference)
+
+    kl_weight: float = 0.0
+    mean_l2_weight: float = 0.0
+    std_reg_weight: float = 0.0
+
+    debug_noise_std: float = 0.05
+
+@attrs.define
+class ActionConditioningConfig:
+    mode: str = "normal"                # normal | zero_video | shuffled_video | dropout_video
+    dropout_prob: float = 0.0
+```
+
+Both are fields of `World2ActionPipelineConfig` and are overridable per
+experiment / on the CLI at
+`model.config.pipe_config.action_source_prior.*` and
+`model.config.pipe_config.action_conditioning.*`.
+
+### Pooling architectures (`pool_type`)
+
+- `mean` — masked/ordinary mean over the video token dimension.
+- `attention` — a single learned query attends to the video tokens.
+- `perceiver` — a small learned latent array cross-attends to the video tokens, then is pooled.
+
+The prior is **horizon-aware**: a learned per-step query is added to the pooled
+global feature, so `mu`/`logstd` differ across the `HA` action steps rather than
+broadcasting a single global vector.
+
+## 5. Experiment matrix
+
+Registered named experiments (`cosmos_predict2/configs/experiment/world2action.py`):
+
+| experiment                       | source mode             | conditioning      |
+|----------------------------------|-------------------------|-------------------|
+| `vlsp_baseline_gaussian`         | gaussian (disabled)     | normal            |
+| `baseline_gaussian`              | gaussian (disabled)     | normal            |
+| `vlsp_source_only_sample`        | video_prior_sample      | zero_video        |
+| `vlsp_source_condition_sample`   | video_prior_sample      | normal            |
+| `vlsp_source_only_mean`          | video_prior_mean        | zero_video        |
+| `vlsp_source_condition_mean`     | video_prior_mean        | normal            |
+| `vlsp_blend_alpha_025/050/075`   | video_prior_blend       | normal            |
+| `vlsp_shuffled_source`           | shuffled_video_prior    | normal            |
+| `vlsp_shuffled_condition`        | video_prior_sample      | shuffled_video    |
+| `vlsp_dropout_020`               | video_prior_dropout     | normal            |
+| `vlsp_residual`                  | video_prior_residual    | normal            |
+| `vlsp_debug_gt_action_noisy`     | gt_action_noisy_debug   | normal            |
+
+These are built on top of a representative base experiment (a libero base when
+available). Sweeps over `blend_alpha`, `residual_scale`, `source_dropout_prob`
+and `sampling_temperature` can be done by overriding the corresponding field on
+the CLI (below).
+
+Full ablation table the code supports without further edits:
+
+```
+A. Baseline                source=gaussian               cond=normal
+B. Source-only stochastic  source=video_prior_sample     cond=zero_video
+C. Source + condition      source=video_prior_sample     cond=normal
+D. Source-only determ.     source=video_prior_mean       cond=zero_video
+E. Source + cond determ.   source=video_prior_mean       cond=normal
+F. Shuffled source ctrl    source=shuffled_video_prior   cond=normal
+G. Shuffled cond ctrl      source=video_prior_sample     cond=shuffled_video
+H. Blend                   source=video_prior_blend      blend_alpha in {0.25,0.5,0.75,1.0}
+I. Residual                source=video_prior_residual   residual_scale in {0.25,0.5,1.0,2.0}
+J. Dropout                 source=video_prior_dropout    source_dropout_prob in {0.1,0.2,0.5}
+K. Temperature             source=video_prior_sample     sampling_temperature in {0.0,0.5,1.0,1.5}
+```
+
+## 6. Example commands
+
+Training uses `scripts.train`. Replace `<base>` with a concrete base experiment
+name (e.g. `w2a_libero_goal_agentview_..._bsz1`) when overriding ad-hoc.
+
+**Gaussian baseline (unchanged behaviour):**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_baseline_gaussian
+```
+
+**VLSP source-only (source uses the video latent, decoder gets zeroed video):**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_source_only_sample
+```
+
+**VLSP source + condition:**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_source_condition_sample
+```
+
+**Shuffled-source negative control:**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_shuffled_source
+```
+
+**Blend-alpha sweep (ad-hoc overrides on any base experiment):**
+
+```bash
+for ALPHA in 0.25 0.5 0.75 1.0; do
+  torchrun --nproc_per_node=4 -m scripts.train \
+    --config=cosmos_predict2/configs/config.py -- \
+    experiment=<base> \
+    model.config.pipe_config.action_source_prior.enabled=true \
+    model.config.pipe_config.action_source_prior.mode=video_prior_blend \
+    model.config.pipe_config.action_source_prior.blend_alpha=$ALPHA \
+    model.config.pipe_config.action_conditioning.mode=normal
+done
+```
+
+**Temperature sweep / KL regularizer (ad-hoc):**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_source_condition_sample \
+  model.config.pipe_config.action_source_prior.sampling_temperature=0.5 \
+  model.config.pipe_config.action_source_prior.kl_weight=1e-4 \
+  model.config.pipe_config.action_source_prior.pool_type=perceiver
+```
+
+**Evaluation** selects the *same experiment name* so the pipeline is built with
+the matching VLSP config; the trained source-prior weights are loaded from the
+action-model checkpoint automatically (`World2ActionPipeline.from_config`):
+
+```bash
+python -m eval.libero.run \
+  --vam-experiment-name vlsp_source_condition_sample \
+  --vam-video-model-path <video.pt> \
+  --vam-action-model-path <action_vlsp.pt> \
+  ...
+```
+
+**Smoke test (no GPU / dataset required):**
+
+```bash
+cd model && python -m scripts.debug_vlsp
+```
+
+## 7. Logging
+
+When the source prior is enabled the following are logged (per training step):
+
+```
+loss/flow, loss/source_prior, loss/source_kl, loss/source_mean_l2, loss/source_std_reg
+source/mu_mean, source/mu_std, source/logstd_mean, source/std_mean
+source/source_mean, source/source_std
+source/source_vs_x0_mse, source/source_vs_gaussian_mse
+source/dropout_rate_actual, source/source_mode_id, source/shuffle_enabled
+condition/mode_id, condition/shuffle_enabled
+```
+
+## 8. Checkpoint compatibility
+
+- The source prior is saved under `source_prior.*` (and `source_prior_ema.*`
+  when EMA is enabled) in the model checkpoint, alongside the existing `net.*` /
+  `net_ema.*` keys.
+- Loading is **non-strict** for the source prior, so:
+  - **Old checkpoints without source-prior keys load fine** — a freshly
+    initialized source prior is kept (and for `mode="gaussian"` there are no
+    source-prior parameters at all).
+  - **A brand-new source prior can be seeded from an old action-decoder
+    checkpoint** (the DiT loads strictly/non-strictly as before; the source prior
+    just starts from its initialization).
+- Both the training `Model.state_dict()/load_state_dict()` path and the
+  inference `World2ActionPipeline.from_config()` path load source-prior weights,
+  so eval picks up trained priors instead of leaving them random.
+
+## 9. Optimizer / parallelism notes & limitations
+
+- The source prior is **always fully trainable** (even under
+  `train_architecture="lora"`, where the DiT only trains LoRA params). Its
+  parameters are added to the optimizer and to `clip_grad_norm_`. In LoRA mode
+  the source-prior params are upcast to fp32 to match the LoRA param group dtype.
+- **DDP (default):** the whole model is DDP-wrapped, so source-prior gradients
+  are synchronized. To keep `find_unused_parameters=False` valid, both prior
+  heads (`mu`, `logstd`) are always kept in the autograd graph for every mode
+  (the unused term is numerically zero), so deterministic modes (`mean`,
+  `residual`) and all-dropout batches do not trip DDP.
+- **EMA:** a simple param-wise EMA of the source prior is maintained for the
+  standard non-FSDP path (`source_prior_ema`), updated with the DiT EMA beta.
+- **FSDP limitation:** the source prior is left **replicated** (not sharded); it
+  is small. Under an FSDP-only run (no DDP wrapper), gradients for replicated
+  parameters are not automatically all-reduced across data-parallel ranks, and
+  FSDP+EMA for the source prior is not specially handled. The default trainer
+  (`distributed_parallelism="ddp"`, `fsdp_shard_size=0`) is unaffected. If you
+  enable FSDP, add explicit gradient synchronization for the source prior or
+  wrap it in its own FSDP unit.
+```

--- a/VLSP.md
+++ b/VLSP.md
@@ -304,4 +304,73 @@ condition/mode_id, condition/shuffle_enabled
   (`distributed_parallelism="ddp"`, `fsdp_shard_size=0`) is unaffected. If you
   enable FSDP, add explicit gradient synchronization for the source prior or
   wrap it in its own FSDP unit.
-```
+
+## 10. Related work & design rationale
+
+VLSP's core idea — replacing the Gaussian flow source with an informative,
+video-conditioned source — is shared by two recent action flow-matching works.
+Reading their code directly shaped several VLSP design decisions.
+
+### A2A — Action-to-Action Flow Matching (RoboVerse)
+- Flows from a **history encoding** (past states/actions → latent, the source)
+  to **future-action latents** (target), with visual obs as a *separate*
+  `global_cond`.
+- Configurable-source interface (`flow_matchers.py`):
+  `x0 = randn_like(target) if start is None else start` — the source is just an
+  optional non-Gaussian `start`.
+- *A2A-Noise* injects Gaussian noise into the history **states** before encoding,
+  as a robustness regularizer.
+- Anti-degeneracy: action-reconstruction + consistency + InfoNCE contrastive losses.
+
+### VITA — Vision-to-Action Flow Matching Policy (ICLR 2026, arXiv:2507.13231)
+- **"noise-free, conditioning-free"**: the flow `start` is the **vision latent
+  itself** (`start = obs_encoder(vision)`, a single `nn.Linear` to `latent_dim`);
+  the target is the **action-AE latent** (same dim); and the flow net
+  `model(x_t, t)` takes **no condition**. The flowed latent is decoded back to
+  actions at the end.
+- Both endpoints live in an **aligned latent space** (vision ↔ action manifolds),
+  so a short MLP flow suffices — *"conventional flow matching may struggle to
+  transport from an unstructured Gaussian to a structured action space."*
+- Anti-degeneracy: action reconstruction (encoder + flow), InfoNCE contrastive
+  (vision↔action), consistency, optional action-VAE KL.
+
+### How VLSP relates / differs
+
+| | A2A | VITA | VLSP (this work) |
+|---|---|---|---|
+| flow space | action-AE latent | aligned vision/action latent | **raw normalized action space** (`x0` = GT action) |
+| source | history encoding | vision latent (`Linear`) | **video latent → prior net** (mean/attention/perceiver pooling, optional diagonal Gaussian) |
+| video as condition | yes (`global_cond`) | no (conditioning-free) | **configurable** (`action_conditioning`: normal / zero_video / …) |
+| anti-collapse | recon + contrastive + consistency | recon + contrastive + consistency + KL | optional KL / mean-L2 / std (default 0) |
+| action autoencoder | yes | yes | **no** (flow directly in action space, like mimic-video) |
+
+**Design notes / consequences**
+
+1. **A learned source map is unavoidable.** The video latent `[B, N, 2048]` and the
+   action source `[B, HA, A]` differ in both shape and space, while
+   `x_t = (1-t)·x0 + t·source` requires the source to match `x0`. VITA's
+   `obs_encoder` (a `Linear`) and A2A's history encoder are the same unavoidable
+   bridge — VLSP's `VideoLatentSourcePrior` is our analog. The minimal,
+   VITA-like form is `source_mode=video_prior_mean` + `pool_type=mean`
+   (deterministic projection, no sampling).
+2. **VITA-style recipe in VLSP.** `source_mode=video_prior_mean` +
+   `action_conditioning=zero_video` reproduces VITA's *source-only,
+   conditioning-free* setup (experiment row D), here in raw action space.
+3. **Source collapse.** Because our source is trainable and `x0` is the fixed GT
+   action, the flow loss admits a degenerate optimum `source → x0 ⇒ u_t → 0` that
+   bypasses the DiT. A2A/VITA prevent this with reconstruction / contrastive /
+   consistency anchoring (and VITA deliberately *aligns* source≈target while
+   keeping both decodable). VLSP currently offers KL / mean-L2 / std regularizers
+   (default 0). **Recommendation**: for `video_prior_*` modes set a small
+   `kl_weight` (e.g. `1e-3`) and watch `source/source_vs_x0_mse`; an optional
+   VITA-style consistency anchor is a natural extension.
+4. **Endpoint convention.** A2A/VITA (torchcfm) put the source at `t=0` and data
+   at `t=1`; mimic-video puts data at `t=0` and the source at `t=1` (the sampler
+   integrates `t: 1→0`). VLSP places the learned source at mimic-video's `t=1`
+   endpoint — exactly where `torch.randn_like(action)` used to be — so the
+   existing sampler/integration is unchanged.
+
+### References
+- **VITA: Vision-to-Action Flow Matching Policy**, ICLR 2026 — arXiv:[2507.13231](https://arxiv.org/abs/2507.13231) · code: https://github.com/ucd-dare/VITA (`flare/policies/vita/vita_policy.py`, `flare/flow/flow_matchers.py`)
+- **A2A — Action-to-Action Flow Matching** (RoboVerse): https://github.com/JIAjindou/A2A_Flow_Matching (`roboverse_learn/il/policies/a2a/`)
+- **MeanFlow** (1-step generative modeling) arXiv:[2505.13447](https://arxiv.org/abs/2505.13447); **Improved Mean Flows** arXiv:2512.02012 — flow-matcher options used by A2A/VITA.

--- a/VLSP.md
+++ b/VLSP.md
@@ -393,7 +393,15 @@ Reading their code directly shaped several VLSP design decisions.
    keeping both decodable). VLSP currently offers KL / mean-L2 / std regularizers
    (default 0). **Recommendation**: for `video_prior_*` modes set a small
    `kl_weight` (e.g. `1e-3`) and watch `source/source_vs_x0_mse`; an optional
-   VITA-style consistency anchor is a natural extension.
+   VITA-style consistency anchor is a natural extension. Important nuance:
+   variance collapse (`logstd → logstd_min`) is a real warning sign but not
+   automatically proof that the policy has no usable signal. In source+condition
+   runs it can still act like a deterministic video-informed source / lower-
+   variance endpoint and improve action generation; the failure mode is when the
+   source becomes task-independent or the action decoder cannot recover from the
+   off-manifold source. Use rollout success, sampled action MSE, source
+   input-sensitivity metrics, and shuffled controls to separate "useful collapsed
+   source" from "collapsed shortcut".
 5. **Endpoint convention.** A2A/VITA (torchcfm) put the source at `t=0` and data
    at `t=1`; mimic-video puts data at `t=0` and the source at `t=1` (the sampler
    integrates `t: 1→0`). VLSP places the learned source at mimic-video's `t=1`
@@ -486,13 +494,33 @@ a bonus.
 
 ## 12. Run log
 
-- **Run 1 (2026-07, LIBERO-goal, B & C with kl=0) — FAILED: fixed
-  task-independent actions.** Root cause: source-prior **variance collapse**
-  (logstd pinned at the −5 floor ⇒ Dirac source) with a suspected
-  input-independent mu; the early "10× faster loss" was this collapse, not
-  learning. Full evidence, three pre-retraining diagnostics
-  (`scripts/vlsp_probe_prior.py`), the Run-2 plan (R1 `vlsp_r1_kl_1e3` /
-  R2 `vlsp_r2_blend_050` / R3 `vlsp_r3_kl_dropout_020`), in-training gates and
-  the new collapse metrics are documented in
-  **[VLSP_RUN1_ANALYSIS.md](VLSP_RUN1_ANALYSIS.md)** — read it before launching
-  any new VLSP run.
+- **Run 1 (2026-07, LIBERO-goal, B & C with kl=0) — revised status after eval
+  setup audit.** The original evaluation setup overstated the failure as fixed,
+  task-independent actions. With the corrected setup, **source+condition (C) can
+  generate task-conditioned actions**, but the LIBERO-goal success rate is still
+  not high. **Source-only (B) remains essentially not viable** in this setting:
+  actions look strange and the zeroed action-condition bottleneck appears too
+  severe. The training-time observation is still valid: `logstd` collapses to
+  the −5 floor, turning the sampled source into an almost deterministic endpoint.
+  The interpretation is therefore weaker and more useful than the first
+  post-mortem: collapse is a risk and must be monitored, but in C it may still
+  provide a beneficial deterministic / low-variance video-informed source rather
+  than being purely harmful. Treat **C vs A** and **C vs shuffled-source** as the
+  decisive tests; treat B as a strict bottleneck diagnostic, not the main
+  performance candidate.
+
+- The original post-mortem in **[VLSP_RUN1_ANALYSIS.md](VLSP_RUN1_ANALYSIS.md)**
+  remains useful for collapse diagnostics (`source/logstd_floor_frac`,
+  `source/mu_batch_std`, `probe/sampled_action_mse_gtvid`) and the Run-2
+  anti-collapse variants (R1 `vlsp_r1_kl_1e3`, R2 `vlsp_r2_blend_050`, R3
+  `vlsp_r3_kl_dropout_020`), but its eval-failure verdict should be read with
+  the correction above.
+
+- **2026-07-05 — active plan: [VLSP_EXECUTION_PLAN.md](VLSP_EXECUTION_PLAN.md).**
+  Supersedes the R1–R3 launch order above and pauses §11 Phases 2–5 until its
+  decision node is resolved. Order: eval/config parity audit (Q0) → E0 oracle
+  probe (Q1) → D2 μ-informativeness on B/C checkpoints (Q2) → A′ baseline eval
+  + source-ablation grid + solver/D3 (Q3) → decision node → revised Run-2
+  (R1′ fixed-σ control, R5′ μ-aux + structured co-dropout main run, R2 blend
+  fallback). Do not launch unmodified R1, σ-free R4, or full FastWAM training
+  before the corresponding gates in that plan pass.

--- a/VLSP.md
+++ b/VLSP.md
@@ -68,6 +68,11 @@ prediction is unnormalized by the existing action unnormalizer.
 | `shuffled_video_prior`  | like `video_prior_sample` with video latents batch-shuffled  | yes            | given seed    |
 | `gt_action_noisy_debug` | `x0 + debug_noise_std * randn` (training/debug only)         | no             | no            |
 
+The exact Gaussian baseline is `enabled=false, mode=gaussian`. The code rejects
+`enabled=true, mode=gaussian` because it is easy to mistake that setting for the
+bit-identical baseline while still enabling VLSP-side metrics / conditioning
+logic.
+
 `action_conditioning.mode` (independent of the source):
 
 | mode             | video latent fed to the action DiT                  |
@@ -159,6 +164,12 @@ available). Sweeps over `blend_alpha`, `residual_scale`, `source_dropout_prob`
 and `sampling_temperature` can be done by overriding the corresponding field on
 the CLI (below).
 
+`source + dropout condition` is supported by the current config surface but is
+not registered as a named experiment yet: use a video-prior source mode and set
+`action_conditioning.mode=dropout_video`. This is different from
+`vlsp_dropout_020`, which drops the **source** back to Gaussian while keeping the
+action DiT condition normal.
+
 Full ablation table the code supports without further edits:
 
 ```
@@ -173,6 +184,7 @@ H. Blend                   source=video_prior_blend      blend_alpha in {0.25,0.
 I. Residual                source=video_prior_residual   residual_scale in {0.25,0.5,1.0,2.0}
 J. Dropout                 source=video_prior_dropout    source_dropout_prob in {0.1,0.2,0.5}
 K. Temperature             source=video_prior_sample     sampling_temperature in {0.0,0.5,1.0,1.5}
+L. Source + dropout cond   source=video_prior_sample     cond=dropout_video, dropout_prob in {.1,.2,.5}
 ```
 
 ## 6. Example commands
@@ -202,6 +214,16 @@ torchrun --nproc_per_node=4 -m scripts.train \
 torchrun --nproc_per_node=4 -m scripts.train \
   --config=cosmos_predict2/configs/config.py -- \
   experiment=vlsp_source_condition_sample
+```
+
+**VLSP source + dropout condition (ad-hoc; not a registered experiment name):**
+
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- \
+  experiment=vlsp_source_condition_sample \
+  model.config.pipe_config.action_conditioning.mode=dropout_video \
+  model.config.pipe_config.action_conditioning.dropout_prob=0.2
 ```
 
 **Shuffled-source negative control:**
@@ -295,15 +317,14 @@ condition/mode_id, condition/shuffle_enabled
   heads (`mu`, `logstd`) are always kept in the autograd graph for every mode
   (the unused term is numerically zero), so deterministic modes (`mean`,
   `residual`) and all-dropout batches do not trip DDP.
-- **EMA:** a simple param-wise EMA of the source prior is maintained for the
-  standard non-FSDP path (`source_prior_ema`), updated with the DiT EMA beta.
-- **FSDP limitation:** the source prior is left **replicated** (not sharded); it
-  is small. Under an FSDP-only run (no DDP wrapper), gradients for replicated
-  parameters are not automatically all-reduced across data-parallel ranks, and
-  FSDP+EMA for the source prior is not specially handled. The default trainer
-  (`distributed_parallelism="ddp"`, `fsdp_shard_size=0`) is unaffected. If you
-  enable FSDP, add explicit gradient synchronization for the source prior or
-  wrap it in its own FSDP unit.
+- **EMA:** a simple param-wise EMA of the source prior is maintained
+  (`source_prior_ema`), updated with the DiT EMA beta. Validation / inference
+  under `ema_scope()` switches both the DiT and the source prior to their EMA
+  weights, then restores both.
+- **FSDP:** the source prior is left **replicated** (not sharded), because it is
+  small. FSDP initialization broadcasts the replicated source-prior weights, and
+  `World2ActionModel.on_after_backward()` explicitly averages its gradients
+  across the replicate group before the optimizer step.
 
 ## 10. Related work & design rationale
 
@@ -356,7 +377,16 @@ Reading their code directly shaped several VLSP design decisions.
 2. **VITA-style recipe in VLSP.** `source_mode=video_prior_mean` +
    `action_conditioning=zero_video` reproduces VITA's *source-only,
    conditioning-free* setup (experiment row D), here in raw action space.
-3. **Source collapse.** Because our source is trainable and `x0` is the fixed GT
+3. **Source-only is a strict bottleneck, not necessarily the strongest final
+   model.** In rows B/D the video latent tokens can reach the action decoder only
+   after being compressed into `source: [B, HA, action_dim]`; the action DiT sees
+   `zero_video` instead of the full `[B, N, D]` video token set. This cleanly tests
+   whether "video as source" carries useful signal by itself, but it can lose
+   spatial/object/future-state detail. Row C/E (`source + condition`) is the main
+   performance candidate; row L (`source + dropout condition`) is the softer
+   middle ground if we want to encourage reliance on the source without fully
+   cutting the condition path.
+4. **Source collapse.** Because our source is trainable and `x0` is the fixed GT
    action, the flow loss admits a degenerate optimum `source → x0 ⇒ u_t → 0` that
    bypasses the DiT. A2A/VITA prevent this with reconstruction / contrastive /
    consistency anchoring (and VITA deliberately *aligns* source≈target while
@@ -364,7 +394,7 @@ Reading their code directly shaped several VLSP design decisions.
    (default 0). **Recommendation**: for `video_prior_*` modes set a small
    `kl_weight` (e.g. `1e-3`) and watch `source/source_vs_x0_mse`; an optional
    VITA-style consistency anchor is a natural extension.
-4. **Endpoint convention.** A2A/VITA (torchcfm) put the source at `t=0` and data
+5. **Endpoint convention.** A2A/VITA (torchcfm) put the source at `t=0` and data
    at `t=1`; mimic-video puts data at `t=0` and the source at `t=1` (the sampler
    integrates `t: 1→0`). VLSP places the learned source at mimic-video's `t=1`
    endpoint — exactly where `torch.randn_like(action)` used to be — so the
@@ -378,8 +408,8 @@ Reading their code directly shaped several VLSP design decisions.
 ## 11. Experiment protocol & order (go/no-go)
 
 Run experiments **cheapest-to-validate / most-decisive first**, with a go/no-go
-gate between phases. The letters (A–K) refer to the matrix in §5; the names are
-the registered experiments from §6.
+gate between phases. The letters (A–L) refer to the matrix in §5; most names are
+registered experiments from §6, while L is an ad-hoc override.
 
 ### Phase 0 — Plumbing / sanity (cheap, do first, don't skip)
 1. `cd model && python -m scripts.debug_vlsp` (the CPU smoke test).
@@ -421,10 +451,15 @@ the registered experiments from §6.
 9. **kl dial**: sweep `kl_weight ∈ {0, 1e-3, 1e-2}` on the best config while watching
    `source/source_vs_x0_mse`. This characterizes whether the source is a *hint*
    (mse stays up; DiT does the work) or *the answer* (mse → 0; DiT bypassed).
+10. **Source + dropout condition** (**L**, ad-hoc override): if B is too weak but
+    C is strong, train C with `action_conditioning.mode=dropout_video` and sweep
+    `dropout_prob ∈ {.1,.2,.5}`. This tests whether we can reduce over-reliance on
+    the direct cross-attention condition without imposing the full source-only
+    bottleneck.
 
 ### Phase 5 — Sweeps (lowest priority; only after Phases 2–3 are positive)
-10. On the winning config: blend `α∈{.25,.5,.75}` (**H**), dropout `p∈{.1,.2,.5}`
-    (**J**), residual scale (**I**), temperature (**K**), pooling
+11. On the winning config: blend `α∈{.25,.5,.75}` (**H**), source dropout
+    `p∈{.1,.2,.5}` (**J**), residual scale (**I**), temperature (**K**), pooling
     (`mean|attention|perceiver`). These are tuning, not validation of the claim.
 
 ### Minimal decisive set (if compute is tight): **A · C · B · F**

--- a/VLSP.md
+++ b/VLSP.md
@@ -374,3 +374,76 @@ Reading their code directly shaped several VLSP design decisions.
 - **VITA: Vision-to-Action Flow Matching Policy**, ICLR 2026 — arXiv:[2507.13231](https://arxiv.org/abs/2507.13231) · code: https://github.com/ucd-dare/VITA (`flare/policies/vita/vita_policy.py`, `flare/flow/flow_matchers.py`)
 - **A2A — Action-to-Action Flow Matching** (RoboVerse): https://github.com/JIAjindou/A2A_Flow_Matching (`roboverse_learn/il/policies/a2a/`)
 - **MeanFlow** (1-step generative modeling) arXiv:[2505.13447](https://arxiv.org/abs/2505.13447); **Improved Mean Flows** arXiv:2512.02012 — flow-matcher options used by A2A/VITA.
+
+## 11. Experiment protocol & order (go/no-go)
+
+Run experiments **cheapest-to-validate / most-decisive first**, with a go/no-go
+gate between phases. The letters (A–K) refer to the matrix in §5; the names are
+the registered experiments from §6.
+
+### Phase 0 — Plumbing / sanity (cheap, do first, don't skip)
+1. `cd model && python -m scripts.debug_vlsp` (the CPU smoke test).
+2. Short runs (a few hundred–1k steps, no convergence needed):
+   - `vlsp_baseline_gaussian` — confirm the baseline trains **and matches the
+     original mimic-video numbers** (regression check: VLSP disabled must be
+     bit-identical to upstream).
+   - `vlsp_source_condition_sample` — confirm the source-prior path trains: loss
+     decreases, all `source/*` + `loss/*` metrics log, checkpoint save/load
+     round-trips, no DDP unused-parameter error.
+   - `vlsp_debug_gt_action_noisy` — near-oracle source; confirm the decoder can
+     overfit (sanity that the pipeline itself is healthy).
+- **Gate:** all three short runs healthy → Phase 1. Otherwise fix plumbing first.
+
+### Phase 1 — Baseline (the anchor number)
+3. Full train + eval `vlsp_baseline_gaussian` (LIBERO/Bridge). **Lock the
+   seed / dataset / compute / eval protocol here**; every later run reuses it.
+
+### Phase 2 — Core hypothesis: does the video-latent source help? (min. 2 runs)
+4. `vlsp_source_condition_sample` (**C** = video source + normal condition).
+   - **C vs A**: only the source differs (both keep the video condition) ⇒ the
+     cleanest "does the video-latent source add value" comparison. **Primary result.**
+5. `vlsp_source_only_sample` (**B** = video source + `zero_video`).
+   - **B vs A**: can the source *replace* the cross-attention condition (stronger
+     claim). **B vs C**: how much the condition still contributes given the source.
+- **Gate:** if C shows no meaningful gain over A, do **not** start sweeps — go to
+  Phase 4 (kl / determinism) to understand why (likely collapse or a too-weak prior).
+
+### Phase 3 — Negative controls (prove it's signal, not capacity) — run as soon as C looks positive
+6. `vlsp_shuffled_source` (**F** = source from batch-shuffled video).
+   - If **F ≈ C**, the gain is just extra params / a smaller-variance source / a
+     loss-scale artifact — **not** video information. **Stop and rethink.**
+7. `vlsp_shuffled_condition` (**G**) — controls the conditioning pathway.
+- **Gate:** controls **must** degrade vs C/A. If they don't, do not proceed to sweeps.
+
+### Phase 4 — Mechanism ablations + the collapse dial
+8. **Deterministic vs stochastic**: `vlsp_source_only_mean` / `vlsp_source_condition_mean`
+   (**D/E**) vs B/C — does the reparameterized noise matter? (`mean` ≈ VITA-style.)
+9. **kl dial**: sweep `kl_weight ∈ {0, 1e-3, 1e-2}` on the best config while watching
+   `source/source_vs_x0_mse`. This characterizes whether the source is a *hint*
+   (mse stays up; DiT does the work) or *the answer* (mse → 0; DiT bypassed).
+
+### Phase 5 — Sweeps (lowest priority; only after Phases 2–3 are positive)
+10. On the winning config: blend `α∈{.25,.5,.75}` (**H**), dropout `p∈{.1,.2,.5}`
+    (**J**), residual scale (**I**), temperature (**K**), pooling
+    (`mean|attention|perceiver`). These are tuning, not validation of the claim.
+
+### Minimal decisive set (if compute is tight): **A · C · B · F**
+`vlsp_baseline_gaussian` · `vlsp_source_condition_sample` · `vlsp_source_only_sample`
+· `vlsp_shuffled_source`. These four answer the core question: *does the
+video-latent source help, and is it real (video) information?* Everything else is
+a bonus.
+
+### Discipline (applies to every run)
+- **Same seed / dataset / compute / eval protocol**; vary only the axis under test.
+- **Do NOT compare runs on the raw flow loss** (`loss/flow`). The baseline regresses
+  `noise − x0` while VLSP regresses `source − x0`, so their loss magnitudes are not
+  comparable — a smaller VLSP loss can be pure scale, not better learning. Compare on
+  **scale-invariant, source-independent metrics**: the unnormalized action prediction
+  MSE after full sampling (validation `gtvid/full`, `genvid/full`) and/or eval success
+  rate. (E.g. an early "10× faster" must be confirmed on these, not on the loss.)
+- Always check **`genvid/*`** (generated-video conditioned), not only `gtvid/*`
+  (GT-video) — generated video is what inference actually uses, so this is where the
+  train/inference gap shows up.
+- Standing monitors: `success_rate`, validation action MSE, `source/source_vs_x0_mse`,
+  `source/source_vs_gaussian_mse`, `source/std_mean`, `loss/source_kl`.
+- Honor the **go/no-go gates** — if a phase is unhealthy, go back; don't pile on runs.

--- a/VLSP_ANALYSIS_PROMPT.md
+++ b/VLSP_ANALYSIS_PROMPT.md
@@ -1,0 +1,218 @@
+# VLSP 项目分析请求 (Video-Latent Source Prior for Action Flow)
+
+> 用途:发送给独立分析 agent 的自包含 prompt。仓库内配套文档:
+> `VLSP.md`(方法/配置/协议)、`VLSP_RUN1_ANALYSIS.md`(Run-1 证据与诊断)、
+> `VLSP_EXPERIMENT_PLAN.md`(分阶段实验计划)。本文件与它们保持一致,冲突时以
+> 仓库文档 + 训练标量为准。
+
+你是一个研究分析 agent。请基于以下完整背景,回答文末 §5 的分析问题。
+
+## 1. Motivation
+
+在 flow-matching 动作模型中,动作由「从 source 端点积分到动作」生成,基线 source 是高斯噪声
+(`randn_like(action)`)。VLSP 的假设:视频世界模型的(部分去噪)latent 已经包含对未来动作的
+预测信息,应当用它来**初始化**动作生成过程(定义 flow 的 source 端点),而不只是当 cross-attn
+条件。即:
+
+    x_t = (1-t)·a + t·s      u_t = s − a      L = ||v_θ(x_t,t,c) − u_t||² + λ·KL
+    baseline: s ~ N(0,I)     VLSP: s ~ q_φ(s | video_latent, ...)   # 归一化动作空间
+
+相关工作:VITA (ICLR 2026, arXiv:2507.13231) 用视觉 latent 直接当 flow source(noise-free、
+conditioning-free,靠动作 AE + 重建/对比/一致性锚定);A2A (RoboVerse) 用历史状态编码当 source、
+视觉当条件(source 与 target 不同源,结构上防坍缩)。VLSP 与两者的差异:flow target 是**原始
+GT 动作**(无动作 AE),source 网络自由可训——这带来独有的坍缩风险(见 §3)。
+
+## 2. Implementation(细化到算子与张量维度)
+
+### 2.1 共同的 flow 约定(两个 backbone 一致)
+训练:`x_t = (1−t)·x0 + t·s`,回归目标 `u_t = s − x0`(velocity),loss = MSE。
+推理:从 `s`(t=1)出发,Euler 积分 t:1→0。**VLSP 只替换 s 的来源**,插值式、
+target 公式、采样循环全部不动;`s` 与 `x0` 同形状、同归一化动作空间。
+
+### 2.2 mimic-video 的 source prior 网络(VideoLatentSourcePrior)
+
+**输入张量**(LIBERO 配置,B=batch):
+- 视频 latent = 冻结 Cosmos video DiT 在 `xattn_layer_idx=20` 的 hidden states:
+  `[B, T_lat, H_lat, W_lat, 2048]` → reshape → `crossattn_emb [B, N, 2048]`,N=T·H·W
+  (训练时该 latent 处于随机采样的视频噪声级 σ_v;`detach_video_latents=true` 切断回传)。
+- 机器人状态 `state [B, HO, 10]`(HO=观测步数);视频噪声级 `σ_v [B, 1]`;
+- GT 动作 `x0 [B, HA, 10]`,HA = max_horizon(61) − HO,动作维 A=10。
+
+**前向逐步维度变换**(hidden=1024):
+1. `ctx_norm = LayerNorm(2048)`:`[B,N,2048] → [B,N,2048]`。
+2. **池化(3 选 1,输出统一 `h [B,1024]`)**:
+   - `mean`:token 维求均值 `[B,N,2048] --mean(dim=1)--> [B,2048] --Linear(2048→1024)--> [B,1024]`;
+   - `attention`:`kv=Linear(2048→1024)` 得 `[B,N,1024]`;1 个可学 query `[1,1,1024]`
+     expand→`[B,1,1024]`;`MultiheadAttention(1024, 8头, batch_first)` 做 1×N cross-attn
+     → `[B,1,1024] --取[:,0]--> [B,1024]`;
+   - `perceiver`:8 个可学 latent `[1,8,1024]`→`[B,8,1024]` 对 `kv [B,N,1024]` cross-attn
+     → 残差相加 → 残差 MLP → `[B,8,1024] --mean(dim=1)--> [B,1024]`。
+3. **条件注入(逐项加到 h 上,均可开关)**:
+   - state:`[B,HO,10] --mean(dim=1)--> [B,10] --Linear(10→1024)--> [B,1024]`,h += ;
+   - 视频噪声级:`σ_v [B,1] --σ/(1+σ)--> [B] --正弦嵌入(1024维)--> [B,1024] --Linear(1024→1024)-->`,h += ;
+   - 语言(默认关):`[B,L,D_lang] --mean(dim=1)--> [B,D_lang] --LazyLinear(→1024)-->`,h += 。
+   缺失输入时走 `0.0·proj(zeros)` 零系数分支,保证参数始终在计算图里(DDP/FSDP 安全)。
+4. **horizon 感知展开**:可学查询 `horizon_queries [1,61,1024]` 切片 `[:, :HA]`,与
+   `h.unsqueeze(1) [B,1,1024]` 广播相加 → `[B,HA,1024]`;过残差 trunk
+   (`LayerNorm → depth×(Linear 1024→1024 + GELU)`,残差连接)→ `[B,HA,1024]`。
+   ⇒ 每个动作步有独立表征,而非单向量盲广播。
+5. **双头输出**:`mu_head Linear(1024→10)` ⇒ `μ [B,HA,10]`;
+   `logstd_head Linear(1024→10)` ⇒ clamp 到 `[logstd_min=−5, logstd_max=1]` ⇒ `logσ [B,HA,10]`。
+   初始化:μ 头全零(初始 μ≡0)、logstd bias=init_logstd(−1) ⇒ 初始 q≈N(0, e⁻²·I)。
+
+**source 生成(全部在 `[B,HA,10]` 上逐元素)**,ε~N(0,I) 同形:
+- `video_prior_sample`: s = μ + temperature·e^{logσ}·ε(reparameterized)
+- `video_prior_mean`:  s = μ(确定性)
+- `video_prior_residual`: s = ε + residual_scale·μ
+- `video_prior_blend`: s = α·(μ+e^{logσ}ε) + √(1−α²)·ε′
+- `video_prior_dropout`: s = m·s_video + (1−m)·ε′,m~Bernoulli(1−p),
+  粒度 sample→`[B,1,1]` / element→`[B,HA,10]` 广播
+- `shuffled_video_prior`: 先 `crossattn_emb[randperm(B)]` 再走 sample(负对照)
+- 恒加 `s += 0.0·(μ.mean()+logσ.mean())`:数值为零,只为让两头始终留在 autograd 图
+  (DDP `find_unused_parameters=False` / 确定性模式安全)。
+
+**训练接入**(`world2action_model.training_step`):先采 source(gaussian 时 =原 epsilon,
+**保持原 RNG 顺序**:source 在 t 之前抽)→ 再采 t → `x_t=(1−t)x0+t·s`、`u=s−x0` →
+DiT 前向(obs_dropout=0.2)→ `loss = 10·MSE + λ_KL·KL + ...`,
+KL = ½(μ²+σ²−1−2logσ).mean()。**条件通路独立配置**:`prepare_action_condition` 对
+crossattn_emb 做 normal(原样)/ zero_video(置零 `[B,N,2048]→0`)/ shuffled_video
+(batch 置换)—— source 输入与 DiT 条件互不影响,这就是 B/C 实验的实现基础。
+
+**推理接入**(`World2ActionPipeline.__call__`):原 `arch_invariant_rand` 画的
+`[B,HA,10]` 起点替换为 `sample_action_source(...)`;之后 10 步 Euler(t:1→0,dt=−0.1)
+的去噪循环、以及最终 unnormalize 完全不动。**一个与坍缩分析相关的细节**:`denoise()`
+在进 DiT 前做 `x_t / √((1−t)²+t²)` 的单位方差重标定——该公式隐含 **Var[s]=1** 的假设;
+σ 坍缩(Var[s]≈0)时 t≈1 处的实际输入尺度 ≈ 期望的 1/√2 倍,重标定失配。
+
+**诊断指标的精确定义**(hardening 后新增):
+- `source/mu_batch_std = μ.std(dim=0).mean()`:先对 **batch 维**求 std(逐 (step,dim)),
+  再平均 ⇒ ≈0 意味着「μ 对输入不敏感/所有视频同一条轨迹」(Run-1 的盲点;旧的全局
+  `mu_std=μ.std()` 分不清这个);另有 `mu_horizon_std = μ.std(dim=1).mean()`(跨步多样性)。
+- `source/logstd_floor_frac = (logσ ≤ −5+0.05).float().mean()`:钉在 clamp 下限的元素占比
+  (Run-1 全程 ≈1.0)。
+- 其它:`source_vs_x0_mse`、`source_vs_gaussian_mse`、`std_mean/min/max`、
+  训练中采样探针 `probe/sampled_action_mse_gtvid`(每 500 iter 完整采样一次算动作 MSE)。
+
+**工程保障**:enabled=false ⇒ 模块零参数、逐位复现基线(含 RNG 流,已验证);
+`enabled=true+mode=gaussian` 被显式拒绝(歧义配置);FSDP 下 source-prior 梯度手动
+all-reduce;source prior 纳入 EMA;ckpt 以 `source_prior.*` 前缀非严格加载(旧 ckpt 兼容),
+eval 路径 `from_config` 也会加载 prior 权重。
+
+### 2.3 FastWAM 的移植(维度差异 + 接缝方式)
+
+**输入/输出维度**(与 mimic-video 的关键不同):
+- 动作 `[B, T, A]`:T=action_horizon,A=7(LIBERO)/14(RoboTwin);
+- source prior 输入 = **干净首帧 VAE latent** `[B, 48, 1, h′, w′]`,h′=H/16
+  (224×224 ⇒ 14×14),flatten `permute+reshape` → `[B, 196, 48]`——**注意 token 维只有
+  48**(mimic-video 是 2048),信息容量低得多;
+- prior 结构同 2.2(hidden=512,horizon_queries `[1,64,512]`,μ/logσ 头 `Linear(512→A)`),
+  proprio 经 `Linear(proprio_dim→512)` 注入。
+
+**接缝(Template-Method,+564/−0 行)**:base `FastWAM` 上加
+`_make_action_source(gaussian, video_latent, ...)`——disabled 时**原样返回传入的
+gaussian**(逐位等于基线);enabled 时把该 gaussian 复用为 reparam 的 ε(确定性/种子
+从调用点继承)。三个变体的 randn 位点各改 1–2 行:base `training_loss`(用
+`input_latents[:,:,0:1]`,即 VAE 编码 GT 视频的首帧——与推理用的 `first_frame_latents`
+是同一分布)/ base `infer_joint`/`infer_action` / joint `infer_action` / idm
+`training_loss`+`infer_joint`。prior 注册在 `self.mot` 下 ⇒ 既有 trainer(优化
+`model.dit==mot`)与 ckpt(`mot.state_dict()`, strict=False)零改动。
+
+**结构性差异(分析时重要)**:FastWAM 的 action 分支通过 MoT 混合注意力**每层都能看到
+视频 token**(base 只看首帧 token,joint 看全部)——等效于「永远 source+cond」,不存在
+mimic-video 的 zero_video 开关;因此「μ 无信息压力」问题在 FastWAM 结构上更严重,且
+VLSP-future(部分去噪未来 latent 当 source)尚未实现,当前 source 只含首帧信息。
+
+## 3. 实验现状(Run 1 修正版,关键!)
+
+**先修正一个事实:Run-1 最初报告的「每个 rollout 执行固定的任务无关动作」是 eval 侧
+实验设置问题造成的假象(已定位修复)。修复后重新评估的真实结果:**
+
+- **C(source+cond):能正常生成动作,但成功率不高**(具体数字待补;且当时没有在
+  同一 eval 设置下跑 baseline 对照,无法判断 C 是"低于基线"还是"≈基线")。
+- **B(source-only):完全不行,动作明显怪异**(不是"合理但做错任务",而是运动学上
+  就不像正常轨迹)。
+
+**训练端证据不受 eval 修正影响,以下事实依然成立:**
+- `source/logstd_mean` 钉死在 clamp 下限 −5.0(σ≈0.0067,B、C 两个 run 都是)
+  ⇒ **source 方差坍缩为 per-input Dirac,确凿**。
+- `source/source_vs_x0_mse` 随训练**上升**至 0.81–0.91,且 > Var[x0]≈0.55
+  ⇒ μ 没有坍向 x0,甚至比预测数据均值更差 ⇒ 疑似 **input-independent(近常数)μ**。
+- `loss/flow` 极小(0.006–0.03)⇒ 早期「快 10×」是 target 变可预测的坍缩伪象,不可与
+  baseline 的 loss 直接比较(量纲不同)。
+
+**修正后的联合解读(B/C 行为差分是新的强证据):**
+1. **C 正常但弱** ⇒ cross-attn 条件通路是健康的:即使 source 退化成(近似)确定性起点,
+   DiT 仍能靠条件学出任务相关速度场并积分出合理动作。坍缩没有"摧毁"模型,它的真实代价是
+   ① source 不再提供信息增益(VLSP 的核心假设没兑现),② 失去高斯 source 的噪声鲁棒性
+   (t≈1 处分布过窄,eval 起点对训练分布外的视频 latent 更脆弱)——这两条是 C 成功率
+   不高的候选解释,但**尚不能与"训练量不足 / 生成视频 gap / 本就≈baseline"区分开**。
+2. **B 彻底崩坏** ⇒ source 是 B 唯一的任务信息入口;B 动作怪异(而非"合理但错误")与
+   「μ 近常数 + σ≈0」的预测一致:DiT 只能学"从一个固定起点到各种 x0 的平均场",eval 时
+   输出不连贯/均值化的轨迹。**B 的失败是"μ 不携带视频信息"的行为学证据**,但仍需 D2
+   探针在权重层面确认(喂 K 个不同视频 latent,测 μ 的 cross-input 差异)。
+3. 结构性根因假设(维持):source+cond 训练中 **μ 没有任何携带视频信息的损失压力**
+   (视频信息反正能从 cross-attn 进来,常数 μ 使 target 最可预测);kl_weight=0 则给了
+   σ→0 的明确梯度激励。坍缩(σ)已证实,μ 无信息(μ)待 D2 定罪。
+4. 当前结论边界:**VLSP 的正增益尚未在任何配置中显现**;C 的表现目前无法排除
+   "全部功劳属于 cross-attn 条件、source 白搭甚至略有拖累"这一最保守解释。
+
+## 4. 后续实验计划(修正版)
+
+**第 0 优先:补齐归因所需的对照与诊断(全部便宜,先于任何重训)**
+- **A' — baseline 同设置对照(最重要的缺口)**:用修复后的同一 eval 设置跑
+  `vlsp_baseline_gaussian` 的成功率。没有这个数字,"C 成功率不高"无法归因。
+- **D2 — prior 退化探针(必跑,CPU 数分钟)**:`scripts/vlsp_probe_prior.py` 加载 Run-1
+  ckpt,K 个不同(真实)视频 latent 测 μ 输入敏感度 + logstd floor fraction。预期确认
+  「σ 坍缩 + μ 近常数」;若 μ 其实 input-sensitive,则 B 的崩坏需要另找解释(优先查
+  B 训练本身与 zero_video 下 DiT 的退化)。
+- **D3 — stop-step 扫描(用现有 C ckpt)**:`stop_video_denoising_step ∈ {5,15,25,35}`
+  看 C 成功率是否随视频去噪程度单调变化 ⇒ 分离"生成视频 gap"对低成功率的贡献。
+- **C 失败模式定性**:抽看 C 的失败 rollout,标注是"接近成功的精度问题"还是"系统性
+  偏差/早期就走错"——前者指向训练量/精修,后者指向分布性问题。
+
+**Run 2 = R1–R3(维持,均 source+cond,同 seed/数据/eval),已注册:**
+| Run | 实验名 | 改动 | 理由 |
+|---|---|---|---|
+| R1 主线 | `vlsp_r1_kl_1e3` | kl_weight=1e-3 | 消除 σ→0 梯度激励,source 保持 "hint" |
+| R2 结构兜底 | `vlsp_r2_blend_050` | blend α=0.5 + KL | 不可坍缩的 0.87-std 高斯分量,最坏退化=baseline |
+| R3 鲁棒 | `vlsp_r3_kl_dropout_020` | R1 + 20% source dropout | DiT 保留纯高斯模式 |
+
+**注意:KL 只治 σ 坍缩,不治「μ 无信息压力」这个结构问题。** 因此新增两个候选
+(是否采纳请分析 agent 评估,见 §5-Q3):
+- **R4(候选)— source-only 训练配置作为 μ 的信息压力源**:`zero_video` 训练下 μ 是唯一
+  信息通道,被迫学习 video→action;可作为 curriculum 第一阶段(先 source-only 预训 prior,
+  再切回 source+cond)或独立验证「μ 到底能不能从该视频 latent 学出动作信息」。
+- **R5(候选)— μ 显式监督**:辅助损失 `||μ − x0||²`(小权重,类 VITA 锚定在 raw-action
+  空间的适配),直接给 μ 信息压力;与 KL 并用时注意两者拉扯方向相反,需权重调和。
+
+**训练中 gate(维持并强化,2k/5k/10k iter)**:`logstd_mean > −2.5`;`logstd_floor_frac ≈ 0`;
+`mu_batch_std` 明显 > 0(Run-1 的盲点指标);`probe/sampled_action_mse_gtvid` 下降且与
+baseline 同 iter 可比(禁止拿原始 flow loss 跨 run 比较——量纲不同)。**新增行为学 gate**:
+任何配置宣布"健康"前,必须在修复后的 eval 上给出与 A' 可比的成功率;B(source-only)线
+保持挂起,直到某配置的 `mu_batch_std` 健康(否则 B 必然重蹈覆辙)。FastWAM 侧继续等
+mimic-video 结论。
+
+## 5. 请你分析的问题
+
+1. **B/C 行为差分的解释是否唯一?** 「μ 近常数 + σ 坍缩」能同时解释"C 正常但弱、B 崩坏"
+   吗?B 的怪异动作还有哪些竞争性解释(如 zero_video 训练下 DiT 本身退化、B 的坍缩时间线
+   更早、B/C 除 conditioning 外的其它设置差异)?用什么最小实验区分?
+2. **C 成功率低的归因分解**:候选因子 = ①Dirac source 的 eval 脆弱性(含 §2.2 提到的
+   `x_t/√((1−t)²+t²)` 重标定在 Var[s]≈0 时失配)、②有效训练量不足(loss 早熟不代表学够)、
+   ③生成视频 vs GT 视频 gap(D3)、④本就 ≈ baseline(待 A' 对照)。给出最小实验集把四者
+   分开,并评估各自先验概率。
+3. **KL 之外要不要治 μ?** R1–R3 只防 σ 坍缩;若 D2 确认 μ 无信息,只靠 KL 的 R1 即使
+   "健康"也可能只是回到 ≈baseline(source≈N(0,1) 的白噪声)。R4(source-only 压力/curriculum)
+   与 R5(μ 辅助回归)哪个更值得先做?有没有更好的给 μ 加信息压力的机制(对比学习、
+   信息瓶颈、把 source 与条件做 dropout 互补而非独立)?
+4. **指标体系还缺什么?** 现有:mu_batch_std、mu_horizon_std、logstd_floor_frac、
+   source_vs_x0_mse、采样 MSE 探针 + 行为学 gate。是否需要:μ 与任务标签的可分性探针
+   (linear probe)、source 的 per-task 聚类可视化、eval 起点 OOD 度量(source 与训练
+   source 分布的距离)?
+5. **FastWAM 迁移教训**:FastWAM 的 MoT 混合注意力意味着 action 分支**永远**能看到视频 token
+   (相当于永远 source+cond)⇒ 「μ 无信息压力」问题必然复现;且 VLSP-current 的输入只是
+   首帧 latent(48 维 token,信息量低于 mimic-video 的 2048 维部分去噪未来 latent),μ 可学
+   的上限更低。FastWAM 首跑应该直接带哪些防线(KL 默认开?blend 结构?R4/R5 机制)?以及
+   是否应该先等 mimic-video 的 D2/R1 结论再动 FastWAM?
+6. **行动排序**:给出你认为最优的执行顺序(A'/D2/D3/失败定性 → R1–R3 → R4/R5 的
+   触发条件),并指出哪一步的结果会最大地改变后续决策(最高信息价值)。

--- a/VLSP_EVAL_PARITY.md
+++ b/VLSP_EVAL_PARITY.md
@@ -1,0 +1,159 @@
+# VLSP Eval/Config Parity Audit
+
+Status: Phase-0 tooling implemented on 2026-07-05. The parity gate is **not
+passed yet** because the historical eval logs, run dirs, checkpoints, stats
+JSONs, and result trees are not present in this workspace.
+
+## Tooling Implemented
+
+- `eval/libero/run.py`
+  - Future rollout dirs are collision-free:
+    `<experiment>_<ckpt-stem>_stopafter<k>_execute<n>_seed<seed>/<suite>`.
+  - Each rank writes `config_echo.rank<N>.json` with CLI args, resolved
+    source-prior and conditioning config, scheduler steps, xattn layer,
+    artifact file sizes and sha256 hashes, git commit, and the explicit
+    `weights_loaded="reg"` note. `git commit` carries a `-dirty` suffix when the
+    worktree has uncommitted changes.
+  - **Two-stage collision guard.** A fail-fast CLI-only pre-check runs *before*
+    the (minutes-long) model load and raises on a mismatched experiment name /
+    checkpoint path / stop step / execute count / horizons / suite / trial count
+    / world size / **`num_steps_wait`** / seed. After the model loads, the full
+    guard additionally compares checkpoint **sha256**, stats sha256, and the
+    behaviour-determining resolved config (`source_prior.enabled/mode`,
+    `action_conditioning.mode`, `scheduler.num_denoising_steps`,
+    `xattn_layer_idx`) — so a wrong `--vam_experiment_name` that silently flips
+    `zero_video` (P0-3) is caught even when the CLI paths look identical.
+  - **Soft code-drift check.** A git-commit difference (incl. `-dirty`) does not
+    hard-raise but prints a loud `[VLSP-EVAL-AUDIT][WARN]` so mixing sampler
+    versions in one dir is visible without blocking a legitimate resume.
+  - `config_echo.rank<N>.json` and `summary.rank<N>.json` are written
+    **atomically** (temp file + `os.replace`), so a peer rank's guard never
+    reads a half-written echo.
+  - Each rank writes `summary.rank<N>.json` with per-episode success records.
+- `eval/libero/aggregate_results.py`
+  - Merges rank summaries into `summary.json`, reports total and per-task
+    success, and records missing episode IDs.
+- `model/scripts/vlsp_audit_config.py`
+  - Resolves experiment names through the same `make_config()` plus
+    `override(... experiment=<name>)` path used by eval.
+  - Emits JSON or markdown tables for source-prior, conditioning, scheduler,
+    EMA, net dimensions, xattn layer, offline latent selectors, and data refs.
+    JSON mode stringifies LazyDict `_target_` callables instead of crashing, and
+    `data_config` / `video_dataset_*` are dumped in full so split-identifying
+    kwargs are visible rather than hidden behind a cherry-picked key subset.
+
+## 0.1 Hazard Verdicts
+
+| hazard | verdict | consequence |
+|---|---|---|
+| P0-1 rollout-dir collision + resume contamination | Fixed for future runs by the new label, config echo, invariant guard, and summary JSON. Historical dirs are unaudited. | All historical success numbers remain unverified until their result dirs and invocation logs are classified clean/contaminated/unknown. |
+| P0-2 eval loads non-EMA weights | Code-side verdict: eval loads `net.*` and `source_prior.*` reg weights. Echo records `weights_loaded="reg"`. | Not a mismatch if train/eval probes are compared as reg-weight probes. |
+| P0-3 condition mode carried by `--vam_experiment_name` | Tooling records the literal eval experiment and makes resolved `action_conditioning.mode` / `source_prior.mode` **hard invariants** of the collision guard, so a wrong experiment name that flips `zero_video` now raises instead of contaminating. | Historical B/C evals are fatal/unknown until the literal eval experiment names are recovered. |
+| P0-4 fixed seed on every policy query | Echo records the seed policy. `World2ActionPipeline.__call__` still defaults to `seed=0` per query. | By-design for Phase 0; use identical episode sets across arms. |
+| P0-5 `x_t` rescale assumes unit-variance source | Logged as a known code fact; not changed in Phase 0. | Quantify later via solver/source ablations, not a parity blocker by itself. |
+| P0-6 D1 loading audit | Tool command is documented, but B/C checkpoints are absent locally. | Pending. Any missing `source_prior.*` keys or random-init eval warning voids that eval. |
+
+## Config Snapshot
+
+**Fields that DIFFER across the three registered arms.** These are exactly the
+rows the `--diff` flag keeps:
+
+```bash
+cd mimic-video/model
+python -m scripts.vlsp_audit_config \
+  --experiments vlsp_source_only_sample vlsp_source_condition_sample vlsp_baseline_gaussian \
+  --diff --markdown
+```
+
+| item | vlsp_source_only_sample | vlsp_source_condition_sample | vlsp_baseline_gaussian |
+|---|---|---|---|
+| action_source_prior.enabled | True | True | False |
+| action_source_prior.mode | video_prior_sample | video_prior_sample | gaussian |
+| action_conditioning.mode | zero_video | normal | normal |
+
+**Fields VERIFIED IDENTICAL across all three arms** (from the full,
+non-`--diff` output; `--diff` drops them precisely because they match):
+`scheduler.num_denoising_steps=10`, `pipe_config.xattn_layer_idx=20`,
+`model.config.sampled_mse_probe_interval=500`, `ema.enabled=False`,
+`ema.rate=0.1`, `action_source_prior.logstd_min=-5.0`,
+`action_source_prior.logstd_max=1.0`, `action_source_prior.pool_type=mean`,
+`action_source_prior.kl_weight=0.0`, `net.max_horizon=61`,
+`net.out_channels=10`, `net.crossattn_emb_channels=2048`.
+
+**Findings from this A3 dry-run that change the audit plan:**
+
+1. **The registered variants have `ema.enabled=False`.** B/C therefore had **no
+   EMA** — the P0-2 "reg vs EMA" question collapses to "reg throughout,
+   consistent" *for the registered configs*. Still confirm the literal Run-1
+   config had not overridden `ema.enabled` (see §Required External Inputs).
+2. **Both `offline_video_embedding_dir` and `offline_video_latent_dir` resolve
+   to empty** for every registered variant. But the repo's `LIBERO no-RGB latent
+   training flow` implies Run-1 likely trained from an offline latent/embedding
+   cache — which means Run-1 must have supplied that path (and possibly other
+   knobs) via **CLI overrides or a different registered name**, not the bare
+   variant. Consequence: recovering the *literal* Run-1 launch command (F11) is
+   not optional — the experiment name alone does not reconstruct the training
+   input pipeline, and `video latent source (train)` on the sheet stays
+   `pending` until the full override string is found.
+3. `data_config` resolves to `{"config_name": "libero_object_tenth", "_target_":
+   "<callable ...get_data_config>"}` — i.e. the registered variant defaults to
+   the **object_tenth** split, which does **not** match Run-1's **LIBERO-goal**
+   suite. This is direct evidence (not just suspicion) that Run-1 overrode the
+   data/base config on the CLI; the registered name is a template. Recover the
+   full override string to learn Run-1's actual split (goal_half / goal_tenth /
+   goal_one) and its offline-cache path.
+
+## 0.2 Parity Sheet
+
+Legend: `known` means code/config-side fact verified in this workspace.
+`pending` means it requires external run logs, checkpoints, stats files, or
+result dirs.
+
+| item | B train | B eval | C train | C eval | A' eval |
+|---|---|---|---|---|---|
+| experiment string actually used | pending recover from train log; expected `vlsp_source_only_sample` | pending recover from eval invocation; must resolve to `vlsp_source_only_sample` | pending recover from train log; expected `vlsp_source_condition_sample` | pending recover from eval invocation; must resolve to `vlsp_source_condition_sample` | planned `vlsp_baseline_gaussian` |
+| checkpoint iteration / file / sha256 | pending | pending; future echo records sha256 | pending | pending; future echo records sha256 | pending |
+| weights loaded | reg (registered variant has `ema.enabled=False`; confirm Run-1 did not override) | known eval reg | reg (registered `ema.enabled=False`; confirm Run-1) | known eval reg | known eval reg |
+| normalizer stats JSON | pending data/run config | pending eval flag and sha256 | pending data/run config | pending eval flag and sha256 | pending |
+| source mode | expected `video_prior_sample` | expected `video_prior_sample` if eval name is correct | expected `video_prior_sample` | expected `video_prior_sample` if eval name is correct | `gaussian`, VLSP disabled |
+| condition mode | expected `zero_video` | expected `zero_video` if eval name is correct | expected `normal` | expected `normal` if eval name is correct | `normal` |
+| zero_video implementation identical? | known single `apply_action_conditioning` path | pending only on correct eval experiment name | n/a | n/a | n/a |
+| `stop_video_denoising_step` | n/a for train | pending | n/a for train | pending | pending |
+| video latent source | pending: registered variant has empty offline dirs, so Run-1 used a CLI override / other name — recover the full launch command | generated video latent at stop step | pending: same override recovery required | generated video latent at stop step | generated video latent at stop step |
+| video steps | n/a | known hardcoded 35 in eval | n/a | known hardcoded 35 in eval | known hardcoded 35 in eval |
+| action solver steps | known 10 (registered config) | known 10 (registered config) | known 10 (registered config) | known 10 (registered config) | known 10 (registered config) |
+| `x_t` rescale present | known present | known present | known present | known present | known present |
+| obs_dropout / condition dropout | obs_dropout 0.2 by design; conditioning dropout 0.0 for expected B | eval obs_dropout 0.0; conditioning dropout 0.0 | obs_dropout 0.2 by design; conditioning dropout 0.0 | eval obs_dropout 0.0; conditioning dropout 0.0 | eval obs_dropout 0.0 |
+| proprio path into DiT identical? | known normalized lowdim path | known normalized lowdim path; eval lowdim horizon pending flag | known normalized lowdim path | known normalized lowdim path; eval lowdim horizon pending flag | known normalized lowdim path; eval lowdim horizon pending flag |
+| seed policy | global training RNG; source drawn before flow timestep | known query source seed defaults to 0; env seed 0; paired init states | global training RNG; source drawn before flow timestep | known query source seed defaults to 0; env seed 0; paired init states | known query source seed defaults to 0; env seed 0; paired init states |
+| task split / episode indices | pending | pending eval flags and summaries | pending | pending eval flags and summaries | pending |
+| results dir status | n/a | historical pending; future collision-free guarded dir | n/a | historical pending; future collision-free guarded dir | planned guarded dir |
+
+## History Audit
+
+No local `results/` tree, checkpoint files, train stdout, eval stdout, or stats
+JSONs were found in this workspace during this pass. Historical behavioral
+numbers therefore remain **unknown/unverified**.
+
+| results dir | invocations | episodes on disk / in logs | status | consequence |
+|---|---|---|---|---|
+| pending external collection | pending | pending | unknown | void for Phase-1 decisions until classified or re-run under the fixed harness |
+
+## Required External Inputs
+
+- B run dir `vlsp_source_only_goal_20260701_125625`: checkpoints, startup config
+  dump, and full train log.
+- C run dir `vlsp_source_condition_goal_20260629_183112`: checkpoints, startup
+  config dump, and full train log.
+- Exact historical eval invocations for B/C/A': stdout logs or shell history
+  with `--vam_experiment_name`, checkpoint path, stats JSON, stop step, suite,
+  seed, rank, and world size.
+- Complete historical `results/` tree for contamination classification.
+- Dataset statistics JSON used by each eval.
+- If offline video embeddings were used: `metadata.json` and `video_sigma.npy`.
+
+## Exit Verdict
+
+Phase 0 is not complete. The code-side guardrails and audit tools are in place,
+but B/C behavioral conclusions must remain **unverified** until the historical
+audit is filled or B/C are re-run under the fixed harness.

--- a/VLSP_EXECUTION_PLAN.md
+++ b/VLSP_EXECUTION_PLAN.md
@@ -1,0 +1,471 @@
+# VLSP Execution Plan — Tier-0 Diagnostics → Decision Node → Run-2
+# (VLSP 执行计划：先审计，再诊断，后决策，最后重训)
+
+**Status:** active plan as of 2026-07-05. This plan **supersedes the ordering**
+of `VLSP_RUN1_ANALYSIS.md` §5 (R1–R3 must NOT be launched as-is) and pauses
+`VLSP.md` §11 Phases 2–5 until the Phase-2 decision node below is resolved.
+The Run-1 diagnostics (D1/D2/D3, `model/scripts/vlsp_probe_prior.py`) are
+reused and extended here, not replaced.
+
+**Why this ordering.** Run-1 produced two hard lessons: (a) the flow loss is
+not a success signal (collapse makes the target easy), and (b) an eval
+artifact already inverted one conclusion once. So every GPU-hour below is
+ordered by information-per-hour toward five causal questions:
+
+```
+Q0  Are the eval numbers / configs trustworthy at all?            → Phase 0
+Q1  Does the video latent actually contain action information?    → E0 (1.1)
+Q2  Does Run-1's μ carry action information?                      → D2 (1.2)
+Q3  Is C's low success due to a harmful source, a useless source,
+    the video gap — or is the baseline equally low?               → A′/ablations (1.3–1.6)
+Q4  With σ fixed, how do we make μ actually useful?               → R1′/R5′ (Phase 3)
+```
+
+**Frozen conclusions (do not re-litigate during execution):**
+
+- Run-1's low flow loss is NOT evidence of learning.
+- `logstd` pinned at the −5 floor is structural collapse, not noise.
+- "C runs and is task-conditioned" does NOT show the VLSP source is useful —
+  C also has the cross-attn condition.
+- B's breakdown is important evidence but not sufficient on its own.
+- Unmodified R1–R3 only test "can σ avoid collapse", not "does μ carry
+  information".
+
+**Evidence standard (headline metrics; everything else is supporting):**
+
+| accepted as evidence | explicitly NOT evidence |
+|---|---|
+| batch-centered **R²(μ → x0)** on held-out data (def. in Appendix A) | raw flow loss |
+| **true-source vs shuffled-source gap** (success and/or action MSE) | `source/mu_batch_std` > 0 (necessary, not sufficient) |
+| **few-step sampling curve** (2/5/10/50 steps) vs baseline | "C produces task-conditioned actions" |
+| final **success rate ≥ A′** under the audited, identical eval setup | any number from a non-audited eval dir |
+
+Statistics: ≥ 200 episodes per arm (LIBERO-goal full eval = 10 tasks × 50
+trials = 500). Arms are **paired by construction** if they use the same
+episode indices: `run.py` uses `env.seed(0)` and
+`set_init_state(initial_states[episode_idx])` (eval/libero/run.py:379), so
+always run identical episode index sets across arms and compare per-episode.
+
+---
+
+## Phase 0 — Q0: eval / config parity audit  [blocking; CPU + log reading]
+
+Nothing downstream is interpretable until this passes. Deliverable:
+**`VLSP_EVAL_PARITY.md`** containing §0.1 verdicts + the §0.2 sheet.
+**Detailed implementation plan: [VLSP_PHASE0_AUDIT_PLAN.md](VLSP_PHASE0_AUDIT_PLAN.md)**
+(work items A–D, code sketches, per-row data sources, effort estimates,
+exit checklist).
+
+### 0.1 Repo-level hazards to check first (found by code inspection, 2026-07-05)
+
+| # | Hazard | Where | Action |
+|---|---|---|---|
+| **P0-1** | **Rollout-dir collision + resume contamination.** `run_label = <ckpt stem>_stopafter<k>_execute<n>` contains **no experiment name**. Two runs whose checkpoints share a filename (e.g. every training run saves `iter_000024000.pt`) write into the SAME `./results/...` dir, and the resume scan **skips episodes found on disk and imports their success flags** into the current run's totals. | `eval/libero/run.py:319-322` (label), `:366-376` (resume scan) | Fix: include `vam_experiment_name` + seed in `run_label`. Audit ALL historical result dirs for cross-run reuse; any success number from a shared dir is void and must be re-run. This is the leading candidate for the earlier eval artifact. |
+| **P0-2** | **Eval uses non-EMA (reg) weights.** `from_config` loads `net.*` into the DiT; `net_ema.*` keys are silently dropped (`strict=False`); the source prior loads `source_prior.*` (reg). | `model/cosmos_predict2/pipelines/world2action.py` (`from_config`) | Record `weights=reg` on every eval row. Confirm the in-training probe `probe/sampled_action_mse_gtvid` also uses reg weights so training and eval probes are comparable. |
+| **P0-3** | **The eval condition mode is carried by `--vam_experiment_name`.** `prepare_action_condition` reads `action_conditioning.mode` from the registered experiment config; evaluating B's checkpoint under a non-B experiment name silently disables `zero_video` (and vice versa for C/A′). | `eval/libero/run.py:63`; `pipelines/world2action.py:251-278` | Recover the exact experiment name used in every historical eval. Required pairing: B ↔ `vlsp_source_only_sample`, C ↔ `vlsp_source_condition_sample`, A′ ↔ `vlsp_baseline_gaussian`. Verify train & eval both route through `apply_action_conditioning` (single code path — they do) and that the only `training=True/False` difference is dropout. |
+| **P0-4** | **Fixed seed on every policy query.** `VAMInference._query_policy` calls the pipeline without `seed` → `seed=0` per chunk → the Gaussian/source stochastic draw is identical at every replan. | `run.py:173-181` → `video2world2action.py:35` → `world2action.py:338` | Not necessarily wrong, but must be identical across arms; record it. For the jitter/sample arms of the 1.4 grid, thread an incrementing seed (T4). |
+| **P0-5** | **`x_t` rescale assumes a unit-variance source.** `denoise()` divides by `sqrt((1−t)²+t²)`; with a collapsed source (σ≈0) `x_t` at t≈1 is mis-scaled relative to training statistics. Concrete stiffness suspect for B's weird kinematics. | `pipelines/world2action.py:304` | Log-only in Phase 0; quantified by the solver ablation (1.5). Do not change yet. |
+| **P0-6** | **D1 loading audit.** If `source_prior.*` keys are missing/ignored at eval, the whole behavioral comparison is void. | `from_config` logs; `model/scripts/vlsp_probe_prior.py` (D1) | Run D1 on B and C checkpoints; grep every eval log for `Loaded source_prior from checkpoint (missing=0 …)` vs the `randomly initialized` warning. |
+
+### 0.2 Parity sheet (fill one column per arm; commit to `VLSP_EVAL_PARITY.md`)
+
+| item | B train | B eval | C train | C eval | A′ eval |
+|---|---|---|---|---|---|
+| checkpoint iteration / file | | | | | |
+| weights loaded (reg / EMA) | | | | | |
+| normalizer stats json | | | | | |
+| source mode (`action_source_prior.mode`) | | | | | |
+| condition mode (`action_conditioning.mode`) | | | | | |
+| zero_video implementation identical? (P0-3) | | | | | |
+| `stop_video_denoising_step` | | | | | |
+| video latent source (generated@stop / GT) | | | | | |
+| video steps (`num_sampling_steps`, hardcoded 35 — run.py:123) | | | | | |
+| action solver steps (`scheduler.num_denoising_steps` from experiment cfg — record value) | | | | | |
+| `x_t` rescale present (P0-5) | | | | | |
+| obs_dropout / condition dropout at eval (must be 0 / off) | | | | | |
+| proprio path into DiT identical? | | | | | |
+| seed policy (P0-4) | | | | | |
+| task split / episode indices | | | | | |
+| results dir (post P0-1 fix, collision-free?) | | | | | |
+
+### 0.3 Exit rule
+
+- **Any mismatch** → fix it → **re-run the B and C evals** → downgrade all
+  prior behavioral conclusions to "unverified" until reproduced.
+- **No mismatch** → B/C behavioral differences are admissible evidence for
+  Phases 1–2.
+
+---
+
+## Phase 1 — no-retrain diagnostics (highest information per GPU-hour)
+
+Execution priority: **E0 > A′ > D2 > source-ablation > solver / D3 >
+taxonomy**. E0/D2 (T1–T3) are CPU/1-GPU and must not wait for the sim
+machine; launch A′ on the sim GPUs in parallel.
+
+### 1.0 Tooling (build once; keep eval-only code out of the training path)
+
+| ID | Deliverable | Status |
+|---|---|---|
+| **T1** | `model/scripts/vlsp_dump_pairs.py` — walk the LIBERO train+val dataloaders through the frozen video pipeline **exactly as in training**; dump per sample `{video_tokens [N,2048], x0 [HA,A] normalized, state, context_timestep σ_v, task_id, split}` → `pairs_{split}.pt`. Optional `--from-eval`: same dump but tokens from the generation path at a given `stop_after_step` (reuse the `video2world2action.py:48-68` seam, which already returns `video_sigma`). Output shape doubles as the `--latents` input `vlsp_probe_prior.py` already accepts. | new |
+| **T2** | `model/scripts/vlsp_probe_e0.py` — E0-a/b/c/d probes on T1 dumps (§1.1): data-mean baseline, ridge/linear full-token, attention-pool + linear, small perceiver + linear, and an exact replica of the current prior pooling; batch-centered R², normalized MSE, per-horizon, per-dim, per-σ_v-bin, train/val gap. Pure torch. | new |
+| **T3** | Extend `model/scripts/vlsp_probe_prior.py` — on real pairs add: R²(μ→x0) and linear-probe(μ)→x0; `μ_vs_data_mean_mse`; per-horizon / per-dim R²; μ(true) vs μ(shuffled) vs μ(fixed video); task-id linear probe; `--ckpts` sweep (2k/5k/10k/final); run for **both** B and C. (σ-collapse + input-sensitivity already implemented.) | extend |
+| **T4** | `eval/libero/run.py` additions (eval-only): (a) **run_label fix** (P0-1); (b) `--vam_source_override {learned, shuffled, batch_mean, fixed_mean, gaussian, jitter0.1, jitter0.3, blend0.5}` wrapping `sample_action_source` at `world2action.py:350`; (c) `--vam_action_denoise_steps N` + `--vam_action_solver {euler,heun}` (Heun added to `schedulers/beta_scheduler.py`; Euler unchanged default); (d) `--vam_log_sampler_stats` → per-query `‖v_t‖`, `‖x_t‖`, per-step action delta; (e) per-run `results.json` (per-task successes, episode indices, full config echo incl. overrides) that aggregates the 5 `eval_rank` shards. | new |
+| **T5** | *(optional)* `model/scripts/vlsp_offline_action_mse.py` — offline `sampled_action_mse_gtvid` for any ckpt × source-override on held-out data; cheap pre-filter before sim time. | optional |
+
+### 1.1 E0 — oracle probe: is there action information in the latent? (Q1)
+
+Freeze everything; train only small probes `video latent → x0` on T1 dumps.
+
+| variant | input | model | role |
+|---|---|---|---|
+| E0-a | none | predict `E[x0]` (train mean) | floor: R² ≡ 0 |
+| E0-b | full tokens `[N, 2048]` | linear/ridge; attention-pool + linear; small perceiver + linear | ≈ information ceiling |
+| E0-c | current prior pooling (replicate `pool_type` used in Run-1) | same head as E0-b | measures pooling loss |
+| E0-d | E0-b/c split by training σ_v bins (low/mid/high, from dumped `context_timestep`) | same | which noise level carries signal |
+
+Report: batch-centered **R²** (headline), normalized MSE = MSE/Var[x0],
+per-horizon R², per-dim R² (gripper dim separately), train-val gap. Also run
+E0-b on the `--from-eval` dump at Run-1's stop step → measures the
+**train/eval latent gap** directly.
+
+Reference bands (calibrate against E0-a and the baseline decoder, not as
+hard thresholds): R² < 0.02 no usable info · 0.02–0.05 weak · 0.05–0.15
+usable · > 0.15 strong.
+
+| E0 outcome | conclusion | next |
+|---|---|---|
+| full-token R² ≈ 0 | latent carries ~no action info | **pause Run-2**; change the input (video layer via `xattn_layer_idx`, σ_v range, cleaner latent, VLSP-future, +language/state) |
+| full-token > 0, pooled ≈ 0 | pooling bottleneck | Run-2 must switch pooling (perceiver / horizon-query cross-attn) |
+| both > 0 | input usable | proceed 1.2 / Phase 3 |
+| only low σ_v > 0 | training σ_v too noisy | bias σ_v low or curriculum in Run-2 |
+| early-horizon ≫ late-horizon | source helps short horizon only | evaluate per-horizon from now on |
+| train R² ≫ val R² | probe overfits; weak generalizable info | be conservative in Phase 2 |
+
+### 1.2 D2 — does Run-1's μ carry action information? (Q2)
+
+Run T3 on **B and C separately** (different training pressures), each at
+iterations 2k / 5k / 10k / final, with real held-out pairs.
+
+Report, per checkpoint: (1) σ collapse — `logstd_mean/min/max`,
+`logstd_floor_frac` (>0.9 ⇒ effective Dirac); (2) μ input-sensitivity —
+`mu_batch_std`, pairwise μ distance, μ(true) vs μ(shuffled/fixed);
+(3) **μ action-relevance (core)** — R²(μ→x0), R²(linear(μ)→x0),
+per-horizon/per-dim, `μ_vs_x0_mse` vs `μ_vs_data_mean_mse`; (4) task
+separability — linear probe μ→task_id (supporting only).
+
+| D2 outcome | conclusion | next |
+|---|---|---|
+| floor_frac≈1, mu_batch_std≈0, R²≈0 | textbook Dirac-constant source | C's behavior is condition-driven; B's collapse consistent |
+| floor_frac≈1, mu_batch_std>0, R²≈0 | μ varies with nuisance, not actions | R5′ pressure needed; never cite std as success |
+| C input-sensitive, B constant | C's flat direction landed on an arbitrary sensitive function | check source OOD for C; B does not represent C |
+| R²(μ→x0) clearly > 0 | μ may carry signal | **immediately** run 1.4 to test whether the DiT uses it |
+| B μ informative but B still broken | look at solver stiffness (1.5) / zero_video DiT / eval mismatch (Phase 0) | |
+
+### 1.3 A′ — baseline eval under the audited, identical setup (Q3 anchor)
+
+Answers: is C actually below baseline, at parity, or above?
+
+- **Checkpoint sourcing (decide first):** identify Run-1's exact base
+  experiment + data split from its training config. (i) If an existing
+  baseline action decoder matches that split (see the `w2a_libero_*` entries
+  in `eval/libero/eval.sh`), it may serve as a *provisional* anchor — record
+  the iteration mismatch. (ii) The clean arm is training
+  `experiment=vlsp_baseline_gaussian` (registered; bit-identical baseline,
+  probe on) for the same iterations/budget as Run-1. Do (i) immediately,
+  launch (ii) if any Phase-2 decision hinges on a ≤10 pp difference.
+- **Identical everything** (post-P0 audited): suite/split, episode indices,
+  `stop_video_denoising_step`, video model + 35 steps, action solver steps,
+  normalizer stats, seeds, weights=reg. Only delta: experiment name / source.
+- Command template (from `eval/libero/eval.sh`, post-T4):
+
+```bash
+python run.py \
+  --vam_experiment_name vlsp_baseline_gaussian \
+  --vam_video_model_path <same as Run-1> \
+  --vam_action_model_path <A ckpt> \
+  --vam_dataset_statistics_path <same stats json as Run-1> \
+  --vam_img_horizon 5 --vam_lowdim_horizon 1 \
+  --vam_stop_video_denoising_step <Run-1 value> \
+  --vam_num_execute_actions 5 \
+  --task_suite_name libero_goal --seed 0
+```
+
+- Metrics: success rate (total + per-task), failure categories (1.7),
+  action norm/smoothness/gripper stats, rollout length before failure;
+  paired per-episode comparison vs C.
+
+| A′ vs C | conclusion | next |
+|---|---|---|
+| C ≈ A′ | VLSP currently harmless-but-useless | μ-pressure program (R5′) |
+| C < A′ | source or training interface actively harmful | restore parity first: R1′ / R2 / gating |
+| C > A′ | potential real gain | verify with 1.4 that the source is actually used |
+
+### 1.4 Source-ablation grid on the C checkpoint (Q3: is the source used?)
+
+Eval-only; same checkpoint, replace the source via `--vam_source_override`:
+
+| arm | source fed to the sampler |
+|---|---|
+| 1 learned | μ(c_v) (+σ if not collapsed) |
+| 2 shuffled | μ(c_v′), batch-shuffled videos |
+| 3 batch_mean | μ̄ over the eval batch |
+| 4 fixed_mean | one fixed μ̄ for all queries |
+| 5 gaussian | N(0, I) baseline draw |
+| 6 jitter0.1 | μ + 0.1·ε (incrementing seed, P0-4) |
+| 7 jitter0.3 | μ + 0.3·ε |
+| 8 blend0.5 | 0.5·μ + √0.75·ε |
+
+Metrics: success rate, `sampled_action_mse_gtvid` (T5 offline variant as a
+pre-filter), action norm/smoothness, per-task success, and
+`source_use_gap = Success(true) − Success(shuffled)` (or
+`MSE(shuffled) − MSE(true)`).
+
+| outcome | conclusion | next |
+|---|---|---|
+| learned ≈ shuffled ≈ mean | source behaviorally **inert**; C rides the condition | R1/R2-style runs can only restore stability, not prove VLSP |
+| learned > shuffled | μ informative AND used | focus on source OOD / stability |
+| gaussian > learned | current VLSP source actively hurts | fixed σ / blend / gating first |
+| jitter > learned | Dirac/too-narrow source harmful | fixing σ (or blending) is necessary |
+| jitter < learned | C depends on a deterministic start | be careful with R2 blend |
+| mean ≈ learned but ≠ shuffled | source provides a global bias, not per-video info | cross-check D2 R² and per-task clusters |
+
+### 1.5 Solver ablation on B and C (numerical stiffness vs missing information)
+
+Arms (via T4c): Euler 10 / 20 / 50, Heun 10 / 20. Log per step
+(`--vam_log_sampler_stats`): `‖v_t‖`, `‖x_t‖`, action delta norm,
+jerk/smoothness, early-spike detection — with P0-5 in mind (t≈1 rescale is
+mis-calibrated for a collapsed source).
+
+| outcome | conclusion | next |
+|---|---|---|
+| 50-step / Heun clearly smooths B | Dirac stiffness is a real factor | better solver at eval; high-t loss weighting in training |
+| smoother but still task-wrong | numeric AND information problems coexist | μ pressure + solver |
+| no effect on C | C limited by cond/video-gap/useless source | prioritize A′ / D3 / R5′ |
+| `‖v_t‖` spikes at t≈1 | high-t region unstable | high-t loss profile / solver fix |
+
+### 1.6 D3 — stop-step scan: how much is the video gap? (both C and A′)
+
+`stop_video_denoising_step ∈ {5, 15, 25, 35}` for BOTH arms (the eval.sh
+harness already sweeps stop steps — reuse it with collision-free labels).
+Optional (if time): a teacher-forced GT-latent condition arm via T1-style GT
+dumps. Metrics: success, `sampled_action_mse_gtvid` vs
+`sampled_action_mse_generated`, per-task success, taxonomy labels.
+
+| outcome | conclusion |
+|---|---|
+| C and A′ move together with stop step | video gap is a shared bottleneck, not VLSP-specific |
+| C more sensitive than A′ | VLSP source interacts with the video gap |
+| GT latent ≫ generated | world-model quality is the main bottleneck |
+| insensitive to stop step | bottleneck is decoder / source / training budget |
+
+### 1.7 Failure taxonomy (qualitative, cheap, do alongside 1.3–1.6)
+
+Label ≥ 20 failure MP4s per key arm (rollout dirs already save every
+episode) with: **A** kinematically weird motion · **B** normal motion, wrong
+goal · **C** wrong direction from the start · **D** near-success, precision
+miss · **E** gripper timing wrong · **F** collision/overshoot/jitter ·
+**G** video prediction visibly wrong.
+
+Mapping: A/F → source / solver / action distribution; B/C → condition /
+video gap; D → training budget / precision; E → per-dim issue (check
+per-dim R²); C-normal-but-B-weird → source-only info insufficient or
+zero_video-specific pathology.
+
+---
+
+## Phase 2 — decision node (after 1.1–1.4; at the latest after 1.6)
+
+Do not act on any single number; match the joint pattern:
+
+| # | pattern | conclusion | action |
+|---|---|---|---|
+| 1 | E0 full-token ≈ 0 | source input has no action info | **pause Run-2 entirely**; change input: video layer (`xattn_layer_idx`), σ_v range/curriculum, cleaner latent, VLSP-future, +language/state, or action-AE target. Tuning KL/dropout is pointless here. |
+| 2 | E0 full-token > 0, current pooling ≈ 0 | architecture drops the info | Run-2 with perceiver / horizon-query cross-attn pooling, then #3/#4 logic |
+| 3 | E0 > 0, D2 μ≈0, A′ ≈ C | VLSP harmless-but-useless; C rides the condition | **R5′** (fixed σ + μ-aux + structured co-dropout + source-use metrics) |
+| 4 | E0 > 0, D2 μ≈0, A′ > C | current VLSP actively harmful | first restore parity: **R1′**, R2 blend, source gating, Gaussian fallback; only then R5′ |
+| 5 | D2 μ informative, but 1.4 learned ≈ shuffled | prior learned something; DiT ignores the source | add usage pressure: structured co-dropout, source-only branch, true-vs-shuffled ranking loss, high-t weighting (→ R5′ variants) |
+| 6 | D2 μ informative AND 1.4 learned > shuffled | source already contributes behaviorally | shift to stability: fixed/calibrated σ, solver, source-OOD logging, D3 video gap, few-step curve |
+
+---
+
+## Phase 3 — Run-2 (revised; launch only what Phase 2 licenses)
+
+### 3.1 R1′ — collapse-proof control (`vlsp_r1p_fixed_std05`)
+
+**Question:** with σ fixed, is source+cond at least no worse than baseline?
+
+**Config (zero new training code):** register on top of the existing variant
+machinery (`configs/experiment/world2action.py`):
+
+```
+mode=video_prior_sample, conditioning=normal,
+logstd_min=-0.6931, logstd_max=-0.6931,   # clamp ⇒ σ ≡ 0.5 exactly
+kl_weight=0.0,                            # full KL's μ²/2 pulls μ→0 (action_source_prior.py:667-671) — don't
+mean_l2_weight=0.0,                       # it is ‖μ‖² (pull to zero), NOT a μ-aux (config_world2action.py:81)
+pool_type per E0 outcome
+```
+
+The clamp at `action_source_prior.py:300` makes this a hard fixed σ; the
+logstd head just gets zero gradient. (A cleaner `fixed_std` knob is optional
+polish, not a launch blocker.) Note the existing `vlsp_next_*_floor_m2`
+variants use floor −2.0 ⇒ σ ≥ 0.135 — **weaker than required here**; don't
+substitute them.
+
+**Monitor:** `source/std_mean` (must sit at 0.5), variance by dim/horizon,
+`mu_batch_std`, R²(μ→x0) via T3, flow loss by t-bin, `probe/sampled_action_mse_gtvid`,
+success vs A′, and a 1.4-style learned-vs-shuffled eval at the end.
+
+| gate | handling |
+|---|---|
+| success < A′ | check source scale / solver / blend / P0-5 rescale before touching μ |
+| R²≈0 but success ≈ A′ | fine — that's baseline parity, R1′ passed |
+| R² > 0 and learned > shuffled | unexpected upside → stability analysis (Phase-2 #6) |
+| high-t loss spike | add high-t weighting or solver fix |
+
+### 3.2 R5′ — the actual hypothesis test (`vlsp_r5p_mu_aux_codropout`)
+
+**Question:** with information pressure on μ, does the source yield gains
+beyond baseline?
+
+**Code additions (all additive, VLSP-seam only):**
+
+1. **μ auxiliary**: new `mu_aux_weight` field in `ActionSourcePriorConfig` +
+   `L_mu = w·‖μ − x0‖²` in the prior regularizer (x0 is already passed to
+   the prior during training — the `source/source_vs_x0_mse` metric proves
+   the plumbing exists). Log `loss/source_mu_aux`. Do NOT implement via
+   full KL (μ² term) or `mean_l2_weight` (wrong sign of pressure).
+2. **Structured co-dropout**: config
+   `action_conditioning.co_dropout = {normal: 0.6, source_only: 0.2, cond_only: 0.2}`;
+   draw ONE per-sample mode mask in the training step and apply it
+   consistently to both `sample_action_source` (cond_only ⇒ Gaussian
+   source) and `prepare_action_condition` (source_only ⇒ zero video). Log
+   per-branch flow loss (`loss/flow_normal|source_only|cond_only`). A DiT
+   mode embedding is deferred — it touches original net code (violates the
+   minimal-diff rule) until the gap metrics prove it necessary. If
+   source-use gap stays 0, raise source_only; if success drops, lower it.
+3. **Grad-ratio metric**: `source/grad_ratio_mu_aux_vs_flow` on prior params
+   every K iters; tune `mu_aux_weight` so aux ≈ **10–30 %** of the flow
+   gradient (below: μ won't learn; above: the prior becomes a standalone
+   regressor fighting the flow objective).
+
+**Config:** R1′ fixed σ=0.5 + items 1–3 + pooling per E0 + optional high-t
+loss weighting if 1.5 flagged t≈1.
+
+**Monitor (priority order):**
+- *prior health*: σ fixed, `mu_batch_std`, μ horizon std, R²(μ→x0),
+  per-step/per-dim R², `μ_vs_data_mean_mse`;
+- *source usage*: true-vs-shuffled MSE gap (T5, every N k iters),
+  true-vs-mean success gap, per-branch losses;
+- *flow field*: loss by t-bin, high-t loss, `‖v_t‖` during sampling, x_t
+  norm around the P0-5 rescale;
+- *behavior*: `probe/sampled_action_mse_gtvid`, few-step success
+  (2/5/10/50 via T4c), success vs A′, taxonomy.
+
+**Early gates (~2k/5k):**
+
+| metric | healthy | if not |
+|---|---|---|
+| R²(μ→x0) | clearly rising | with E0 positive: aux weight / architecture / grad-ratio problem |
+| grad ratio | 10–30 % | retune `mu_aux_weight` |
+| `mu_batch_std` | rising, moderate | rising std with flat R² = nuisance variation |
+| source_only branch loss | falling | source carries no usable info yet |
+| t-bin loss | no high-t blow-up | high-t weighting / solver |
+
+**Mid gates:**
+
+| pattern | handling |
+|---|---|
+| R² up, true ≈ shuffled | DiT ignores source → strengthen co-dropout / add ranking loss |
+| true > shuffled, success flat | source useful but capped by video gap / solver / policy bottleneck (D3, 1.5) |
+| success up, few-step flat | gain is regularization, not transport shortening — say so honestly |
+| **few-step clearly beats baseline** | strongest positive VLSP signal — protect and reproduce it |
+| μ train R² ≫ val R² | prior overfits → regularize / shrink / more data |
+
+**Minimum conditions to declare R5′ healthy (ALL required):**
+
+```
+R²(μ→x0) > 0 and a reasonable fraction of the E0 ceiling
+true-source > shuffled-source (behaviorally)
+sampled_action_mse_gtvid better than R1′/A′
+success rate ≥ A′
+few-step curve not worse than baseline (better = headline)
+```
+
+### 3.3 R2 — blend fallback (`vlsp_r2_blend_050`, already registered)
+
+Role: **parity restoration when A′ > C**, not proof of VLSP. Blend keeps an
+un-collapsible √(1−α²)-std Gaussian component. If used, prefer a fixed-σ
+variant (`vlsp_r2p_blend050_fixed_std05`, register like 3.1). Read:
+R2 ≈ A′ ⇒ successful safety net only; R2 > A′ ⇒ possible source gain — must
+pass the 1.4 grid; R2 < C ⇒ Gaussian component interferes or config issue.
+
+### 3.4 Do-NOT list (binding)
+
+1. **No long unmodified R1 (`kl_weight=1e-3`)** — λ=1e-3 may not prevent the
+   floor; if run at all, add the hard floor/fixed σ first.
+2. **No R4 (source-only) without fixed σ=0.5** — with σ≈0, a constant μ can
+   be the *low-loss* solution in source-only; it would train the collapse in
+   harder.
+3. **`mu_batch_std` is a collapse alarm, never a success metric.** Headline
+   = R²(μ→x0) + true-vs-shuffled gap.
+4. **No full FastWAM training now.** Its current source is the clean
+   first-frame latent — a present-conditioned prior, not VLSP's core claim.
+
+---
+
+## Phase 4 — gated restarts
+
+| gate | conditions (ALL) |
+|---|---|
+| **restore B (source-only)** | σ not collapsed · R²(μ→x0) > 0 · true > shuffled · source_only branch loss falls normally in R5′ |
+| **run R4** | E0 positive · R5′ still cannot make the DiT use the source · fixed σ=0.5 mandatory |
+| **FastWAM full training** | mimic-video R5′ positive · FastWAM E0 (below) not negative |
+
+**FastWAM until then (allowed):** E0 probe only — first-frame VAE tokens
+`[B, 196, 48] → x0 [B, T, A]`, pooled / full-token / perceiver variants,
+same R² bands as 1.1 — plus instrumentation, disabled-equivalence check,
+tiny sanity run. If it ever trains: fixed σ=0.5, μ-aux, source-ablation
+metrics, true/shuffled gap, few-step curve, blend on standby. Note the MoT
+always sees video tokens, so the condition path masks μ even more easily
+than in mimic-video — R5-style pressure is *more* load-bearing there.
+
+---
+
+## Appendix A — metric definitions
+
+- **batch-centered R²**: on a held-out set, `R² = 1 − Σ‖ŷ−x0‖² / Σ‖x̄_val−x0‖²`
+  where `x̄_val` is the *held-out* action mean. Report alongside
+  normalized MSE = MSE/Var[x0]. Always beat E0-a before claiming signal.
+- **source_use_gap**: `Success(true) − Success(shuffled)` on paired episodes,
+  or `MSE(shuffled) − MSE(true)` offline. Positive = the DiT uses the source.
+- **few-step curve**: success at 2/5/10/50 action denoise steps (T4c), same
+  arms/episodes. VLSP's transport-shortening claim lives or dies here.
+- **pairing**: identical episode index sets + `env.seed(0)` +
+  `set_init_state(initial_states[episode_idx])` make arms paired by
+  construction; report per-episode deltas, not just totals.
+
+## Appendix B — command quick reference
+
+```bash
+# D1/D2 (existing + T3), from mimic-video/model:
+python -m scripts.vlsp_probe_prior --ckpt <.../model/iter_0000XX000.pt> [--latents pairs_val.pt]
+
+# T1 dumps → E0:
+python -m scripts.vlsp_dump_pairs --split train,val [--from-eval --stop-step <k>]
+python -m scripts.vlsp_probe_e0 --pairs pairs_train.pt pairs_val.pt
+
+# A′ / grid / solver / D3 evals: eval/libero/run.py via eval.sh conventions
+#   (PYTHONPATH=LIBERO etc.), with T4 flags; ALWAYS post-P0-1 run_label fix.
+
+# training launches (Phase 3), from mimic-video/model:
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- experiment=vlsp_r1p_fixed_std05
+```
+
+## Change log
+
+- 2026-07-05 — initial version; grounded in the post-Run-1 causal analysis
+  (Q0–Q4) and a code audit of `eval/libero/run.py`,
+  `pipelines/world2action.py`, `models/action_source_prior.py`,
+  `configs/experiment/world2action.py`. Referenced from `VLSP.md` §12.

--- a/VLSP_PHASE0_AUDIT_PLAN.md
+++ b/VLSP_PHASE0_AUDIT_PLAN.md
@@ -1,0 +1,317 @@
+# VLSP Phase 0 — Eval/Config Parity Audit: Implementation Plan
+# (第一步落地：eval / config parity 审计的详细实现计划)
+
+**Parent:** [VLSP_EXECUTION_PLAN.md](VLSP_EXECUTION_PLAN.md) Phase 0 (question
+Q0). Nothing in Phases 1–3 is interpretable until this passes.
+
+**Deliverables:**
+1. Fixed, auditable eval harness (work item A) — collision-free result dirs +
+   per-run config echo.
+2. Historical-results contamination verdicts (work item B).
+3. `VLSP_EVAL_PARITY.md` — the filled parity sheet + per-arm verdicts (work
+   item C/D).
+4. If any fatal mismatch: re-run B/C evals under the fixed harness (work
+   item D), then amend `VLSP.md` §12.
+
+**Code-fact baseline.** The audit below is grounded in facts already verified
+by code inspection (2026-07-05); the sheet records them so nobody re-derives
+them per-run:
+
+| # | verified fact | where |
+|---|---|---|
+| F1 | `run_label` has no experiment name; resume scan imports on-disk successes → cross-run contamination is possible whenever ckpt filenames collide (every run saves `iter_0000XX000.pt`) | `eval/libero/run.py:319-322`, `:366-376` |
+| F2 | Eval loads **reg** weights: `net.*` → DiT, `net_ema.*` silently dropped; `source_prior.*` (reg) → prior | `pipelines/world2action.py` `from_config` |
+| F3 | The in-training probe `probe/sampled_action_mse_gtvid` samples through `self.pipe` = **reg** weights, seed=0, GT-video condition → probe and eval use the same weight class (comparable) | `models/world2action_model.py:884-902` |
+| F4 | `zero_video` is `torch.zeros_like` on ONE shared code path (`apply_action_conditioning`) for train and eval; `training=True/False` only changes RNG for `shuffled_video`/`dropout_video` | `models/action_source_prior.py:604-643`; call sites `world2action_model.py:835` (train), `pipelines/world2action.py:363-367` (eval) |
+| F5 | Train `obs_dropout=0.2` (hardcoded), eval `obs_dropout=0.0` — **by design**, not a mismatch | `world2action_model.py:458`; `world2action.py:382` |
+| F6 | The `x_t /= sqrt((1−t)²+t²)` rescale lives **inside** `denoise()` → applied identically in training loss and eval sampling. P0-5 is therefore a *distribution/stiffness* question (→ Plan 1.5), **not** a train/eval parity violation | `world2action.py:304`; train path `compute_loss → pipe.denoise` `world2action_model.py:452` |
+| F7 | Eval condition mode is carried by `--vam_experiment_name` (config re-resolved at eval); wrong name silently flips `zero_video` on/off | `eval/libero/run.py:63`; `world2action.py:269-271` |
+| F8 | Every policy query runs with `seed=0` (not threaded through `VAMInference._query_policy`) → identical stochastic source draw at every replan, plus `env.seed(0)` and per-episode `set_init_state(initial_states[episode_idx])` → arms are paired by construction | `run.py:173-181`, `:234`, `:379`; `video2world2action.py:35`; `world2action.py:338` |
+| F9 | Training video latents come from ONE of three paths, config-selected: (a) `offline_video_embedding_dir` → precomputed GT-video hidden states with a **fixed per-sample σ_v** (`video_sigma.npy`), layer checked against `xattn_layer_idx` at load; (b) `offline_video_latent_dir` → offline tokenizer latents + online video DiT with σ_v drawn per step; (c) fully online. Which one Run-1 used is an audit item (C1) | `world2action_model.py:82-89, :164-180, :519-554, :661-722` |
+| F10 | Training draws the source **before** the flow timestep to preserve the baseline RNG order; source uses global RNG at train (`training=True`, no generator) | `world2action_model.py:804-825` |
+| F11 | Run-dir names in Run-1 (`vlsp_source_only_goal_20260701_125625`, `vlsp_source_condition_goal_20260629_183112`) do **not** literally match the registered variant names (`vlsp_source_only_sample`, `vlsp_source_condition_sample`) — the exact `experiment=` strings used at train AND eval must be recovered from logs, not assumed | `configs/experiment/world2action.py:179-262`; `VLSP_RUN1_ANALYSIS.md` |
+| F12 | **A3 dry-run (2026-07-05, CPU) confirms:** the registered `vlsp_*` variants resolve to `ema.enabled=False` and **empty** `offline_video_embedding_dir` / `offline_video_latent_dir`. Since Run-1 almost certainly trained from an offline latent/embedding cache (LIBERO no-RGB flow), it must have set that path (and possibly `ema`, split, etc.) via **CLI overrides or a different registered name**. Recovering only the `experiment=` string is therefore insufficient — the **full launch command / override string** is a required Phase-0 input, and `video latent source (train)` stays `pending` until it is found | `scripts/vlsp_audit_config.py`; `VLSP_EVAL_PARITY.md` §Config Snapshot |
+
+---
+
+## 0. Inputs to collect first (on the training / eval machines)
+
+Gather into one place (e.g. `audit_20260705/`) before touching code:
+
+- [ ] B run dir (`vlsp_source_only_goal_20260701_125625`): checkpoints
+  (`model/iter_0000*.pt`, note exact filenames), the startup config dump in
+  train stdout, full train log.
+- [ ] C run dir (`vlsp_source_condition_goal_20260629_183112`): same.
+- [ ] **Every** historical eval invocation record for B/C (and any baseline):
+  stdout logs, sbatch/tmux/shell history — we need the literal
+  `--vam_experiment_name`, `--vam_action_model_path`,
+  `--vam_stop_video_denoising_step`, `--vam_dataset_statistics_path`,
+  `--task_suite_name`, `--seed`, `--eval_world_size` per invocation.
+- [ ] The complete `results/` tree(s): `find results -maxdepth 2 -type d`.
+- [ ] Training metrics dump `source_cond_vs_source_only_metrics_20260704/`.
+- [ ] If F9(a): the offline embedding dir (`metadata.json`,
+  `video_sigma.npy`) used by Run-1 training.
+
+If an eval invocation's flags cannot be recovered from any log → its numbers
+are classified **unknown** in B3 (same consequence as contaminated: void).
+
+---
+
+## Work item A — eval-harness fixes (eval-only code; no training-path changes)
+
+### A1. Collision-free `run_label` + config echo + contamination guard
+
+**File:** `eval/libero/run.py`. Blocks all future P0-1 recurrences.
+
+1. **Label** (replaces `run.py:319-321`):
+
+```python
+def _short_exp(name: str, keep: int = 40) -> str:
+    if len(name) <= keep:
+        return name
+    return f"{name[:keep]}~{hashlib.sha1(name.encode()).hexdigest()[:8]}"
+
+run_label = (
+    f"{_short_exp(vam_experiment_name)}_{vam_action_model_path.stem}"
+    f"_stopafter{vam_stop_video_denoising_step}_execute{vam_num_execute_actions}"
+    f"_seed{seed}"
+)
+```
+
+   (`_short_exp` keeps the long baseline names from `eval.sh` under path
+   limits; vlsp_* names pass through readable.)
+
+2. **Config echo**: at startup write
+   `rollout_dir / f"config_echo.rank{eval_rank}.json"` containing: all CLI
+   args verbatim; resolved `action_source_prior` fields (enabled, mode,
+   logstd_min/max, kl/mean_l2/std_reg, blend_alpha, source_dropout_prob,
+   pool_type); `action_conditioning.mode`; `ema.enabled` + note
+   `weights_loaded="reg"` (F2); `scheduler.num_denoising_steps`;
+   `xattn_layer_idx`; ckpt path + file size + sha256; stats json path +
+   sha256; git commit of the repo. All fields are readable off
+   `policy.model.world2action_pipeline.config` after construction.
+
+3. **Contamination guard**: before the resume scan, if any
+   `config_echo.rank*.json` already exists in `rollout_dir`, compare the
+   invariant fields (experiment name, ckpt sha256, stop step, suite, seed,
+   stats sha256); on mismatch **raise** with both configs printed. Resume
+   stays allowed only for a byte-identical setup.
+
+4. **Machine-readable summary**: on completion write
+   `rollout_dir / f"summary.rank{eval_rank}.json"`:
+   `{episode_idx: {task_id, task, success}}` + totals. New tiny script
+   `eval/libero/aggregate_results.py --dir results/<run_label>/<suite>`
+   merges shard summaries → `summary.json` (total + per-task success, episode
+   count, missing-episode check against the expected index set). Every
+   Phase-1 arm reuses this.
+
+**Acceptance:** one-task smoke run (`--num_trials_per_task 1`) produces the
+new label, echo, summary; rerunning it resumes cleanly; rerunning with a
+different experiment name against the same dir raises.
+
+### A2. Startup audit log line
+
+Same fields as the echo, one `log.info("[VLSP-EVAL-AUDIT] ...")` line — so
+future audits can grep stdout even when the results dir is lost.
+
+### A3. `model/scripts/vlsp_audit_config.py` (new, CPU-only)
+
+Purpose: fill every *train-side / config-side* row of the parity sheet
+mechanically, and prove what any experiment name resolves to (F7/F11).
+
+```
+python -m scripts.vlsp_audit_config \
+    --experiments vlsp_source_only_sample vlsp_source_condition_sample vlsp_baseline_gaussian \
+    [--diff]         # print only fields that differ from the first experiment
+    [--markdown]     # emit parity-sheet rows directly
+```
+
+Implementation: `make_config()` + `override(config, ["--", f"experiment={name}"])`
+(same code path as eval, `run.py:62-63`), then print:
+
+- `job.name`, `job.group`
+- `action_source_prior.*` (all fields of `ActionSourcePriorConfig`,
+  `configs/config_world2action.py:34-85`)
+- `action_conditioning.*` (`:88-100`)
+- `ema.enabled`, `ema.rate`
+- `scheduler.alpha/beta/num_denoising_steps`
+- `net.max_horizon / out_channels / crossattn_emb_channels`, `xattn_layer_idx`
+- `model.config.offline_video_embedding_dir / offline_video_latent_dir /
+  *_required` (F9 selector), `sampled_mse_probe_interval`
+- best effort: normalizer/data-config identifiers
+
+No GPU, no checkpoint needed. **Also run it with the exact Run-1
+`experiment=` strings recovered per F11** — if those names no longer resolve
+(or resolve to different modes than assumed), that is itself a Phase-0
+finding.
+
+---
+
+## Work item B — historical results audit (retroactive P0-1)
+
+### B1. Inventory + collision detection
+
+On each eval machine:
+
+```bash
+find results -mindepth 2 -maxdepth 2 -type d | sort > audit_20260705/result_dirs.txt
+for d in results/*/*/; do printf "%s\t%d\t%d\n" "$d" \
+  "$(ls "$d" | grep -c '^episode')" \
+  "$(ls "$d" | grep -c '_success_')"; done > audit_20260705/dir_counts.tsv
+```
+
+Parse each `run_label` into `(ckpt_stem, stopafter, execute)`. Join against
+the invocation records from §0: a label is **collision-suspect** if ≥ 2
+distinct `(experiment_name, ckpt_path)` invocations map to it. Note the
+concrete Run-1 hazard: B@`iter_000026000.pt` and C@`iter_000024000.pt` differ
+in stem — but any *same-iteration* pair (B/C/baseline at 24k; re-evals of the
+same ckpt at different code states) collides.
+
+### B2. Per-directory contamination test
+
+For each results dir × each invocation that wrote to it:
+
+1. From that invocation's stdout, extract the episode set it actually
+   executed: lines `Saved rollout MP4 at path .../episode{N}_...`.
+2. Union over all invocations of the same `(experiment, ckpt)`.
+3. Episodes present on disk but in **no** matching log → foreign or
+   unlogged → dir is `contaminated` (foreign proven) or `unknown` (logs
+   incomplete).
+4. Flag any aggregate number that was computed by counting files in a dir
+   (`success`-in-filename over total) — with 5-way sharding (per `eval.sh`)
+   that was the only way to get a total, so contaminated dirs corrupt totals
+   directly.
+
+### B3. Verdict table (goes into `VLSP_EVAL_PARITY.md` §History)
+
+| results dir | invocations (exp, ckpt, date) | episodes on disk / in logs | status | consequence |
+|---|---|---|---|---|
+| … | … | … | clean / contaminated / unknown | keep / **void → re-run** |
+
+**Rule:** only `clean` numbers survive. Everything voided is re-run in D2
+under the A1 harness. Explicitly re-examine the number behind the **"revised
+status after eval setup audit"** paragraph in `VLSP.md` §12 — the earlier
+artifact and this hazard must be reconciled (same root cause or two separate
+issues; write down which).
+
+---
+
+## Work item C — fill the parity sheet
+
+Sheet lives in `VLSP_EVAL_PARITY.md`; columns `B train | B eval | C train |
+C eval | A′ eval(planned)`. How each row is obtained:
+
+| row | source of truth |
+|---|---|
+| experiment string actually used | train stdout config dump; eval logs / shell history (F11) — **never assume** |
+| ckpt iteration / file / sha256 | run dirs; echo (new runs) |
+| weights loaded | constant: train=reg(+EMA tracked), eval=reg (F2); probe=reg (F3) → mark "consistent" |
+| source mode / prior knobs | A3 on the recovered experiment strings |
+| condition mode | A3 (must be: B `zero_video`, C `normal`) + F7 check that the *eval* name resolves the same |
+| zero_video implementation parity | F4 → "single path, zeros, identical"; only remaining check = correct experiment name at eval |
+| video-latent source at train | A3 `offline_*` fields + train log `Using offline video embeddings ...` line (F9); record which of (a)/(b)/(c) |
+| σ_v seen at train | (a): `np.load(video_sigma.npy)` → histogram (min/median/max, save the plot path — feeds E0-d); (b)/(c): `draw_video_sigma` distribution from config |
+| video latent at eval | generated video, `num_sampling_steps=35` hardcoded (`run.py:123`), stopped at `stop_after_step`; sigma at stop returned by `generate_video` and fed to prior + DiT (`video2world2action.py:48-68`) |
+| stop_video_denoising_step | per-invocation flags; Run-1's value is REQUIRED (D3 anchors on it) |
+| action solver | BetaScheduler Euler; `num_denoising_steps` from A3; x_t rescale consistent (F6) |
+| obs_dropout / cond dropout | F5: train 0.2 / eval 0.0 by design; `action_conditioning.dropout_prob` from A3 (0 unless dropout mode) |
+| proprio path | `state_B_HO_O` normalized then into DiT both sides (`world2action.py:345-346`, `world2action_model.py:789-796`); lowdim_horizon from eval flags (=1 in eval.sh) |
+| seed policy | F8; per-invocation `--seed` |
+| normalizer stats | train: data_config; eval: `--vam_dataset_statistics_path` (+sha256). Must match the split B/C trained on |
+| task split / episodes | suite, `num_trials_per_task`, `eval_world_size`, per-shard episode index sets (episodes assigned by `total_episodes % world_size == rank` with pre-increment, `run.py:362-365`) |
+| results dir status | B3 verdict |
+
+Plus the **D1 checkpoint audit** (existing tool, minutes, CPU):
+
+```bash
+cd mimic-video/model
+python -m scripts.vlsp_probe_prior --ckpt <B .../model/iter_000026000.pt>
+python -m scripts.vlsp_probe_prior --ckpt <C .../model/iter_000024000.pt>
+```
+
+Pass = `source_prior.*` key count > 0 **and** every historical eval log shows
+`Loaded source_prior from checkpoint (missing=0 …)` — a `randomly initialized`
+warning in any eval log voids that eval on the spot.
+
+---
+
+## Work item D — verdicts, conditional re-runs, doc updates
+
+### D1. Classify every sheet discrepancy
+
+`fatal` (voids behavioral conclusions; triggers D2) — e.g. wrong eval
+experiment name (F7), contaminated dir (B3), missing source-prior load, wrong
+stats json, differing stop step between compared arms.
+`by-design` (record, no action) — e.g. F5 dropout, train-σ_v vs eval-σ_v
+distribution difference.
+`unknown` (treat as fatal for trust purposes).
+
+### D2. Re-run matrix (only what B3/D1 voided; A1 harness mandatory)
+
+```bash
+# from eval/libero, env per eval.sh (PYTHONPATH=LIBERO, VK_*, etc.)
+python run.py \
+  --vam_experiment_name vlsp_source_condition_sample \        # C — exact recovered name
+  --vam_video_model_path <Run-1 video ckpt> \
+  --vam_action_model_path <C .../iter_000024000.pt> \
+  --vam_dataset_statistics_path <Run-1 stats json> \
+  --vam_img_horizon 5 --vam_lowdim_horizon 1 \
+  --vam_stop_video_denoising_step <Run-1 value> \
+  --vam_num_execute_actions 5 \
+  --task_suite_name libero_goal --seed 0 \
+  --eval_rank {0..4} --eval_world_size 5          # one process per rank, per eval.sh
+# B: same, with vlsp_source_only_sample + <B .../iter_000026000.pt>
+python aggregate_results.py --dir results/<new run_label>/libero_goal
+```
+
+Full suite = 10 tasks × 50 trials = 500 episodes/arm (meets the ≥200 bar);
+identical episode index sets across arms (F8 pairing).
+
+### D3. Documentation + commit
+
+- `VLSP_EVAL_PARITY.md`: sheet + B3 history table + D1 verdicts + (if run)
+  corrected B/C numbers with per-task breakdown.
+- `VLSP.md` §12: amend the Run-1 revised-status paragraph if corrected
+  numbers move the story; link the parity doc.
+- Commits (submodule first, then parent pointer, per repo workflow): one for
+  A1/A2/A3 (eval tooling), one for the audit docs. Trailer:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+## Execution order, dependencies, effort
+
+| step | depends on | runs on | est. effort |
+|---|---|---|---|
+| §0 collect inputs | — | GPU/eval machine (file copy) | 0.5–1 h |
+| A3 audit script + run on all names | — | laptop CPU | 1–1.5 h |
+| A1 + A2 harness fix + smoke | — | laptop CPU + 1 short sim run | 1.5–2 h |
+| B1–B3 history audit | §0 | laptop (logs local) | 1–2 h (log-quality dependent) |
+| C sheet fill + D1 probe | §0, A3, B3 | laptop CPU | 1–1.5 h |
+| D1 verdicts | C | — | 0.5 h |
+| D2 re-runs (if triggered) | A1, D1 | eval GPUs | ~1 GPU-day wall-clock for B+C full suites (sharded ×5) |
+| D3 docs + commits | all | laptop | 0.5 h |
+
+Parallelization: A3/A1 can start immediately while §0 collection runs; B and
+C audits are independent. Everything except D2 is CPU-only.
+
+## Exit checklist (gate to Phase 1 of the execution plan)
+
+- [ ] A1 merged: new labels include experiment+seed; config echo + summary
+      json written; echo-mismatch guard raises; aggregator works.
+- [ ] Exact Run-1 `experiment=` strings recovered and resolved via A3 (F11).
+- [ ] Every historical results dir classified clean/contaminated/unknown;
+      voided-numbers list written; the earlier "eval setup audit" correction
+      reconciled with B3 findings.
+- [ ] D1 pass on both B and C checkpoints (keys present + load line in logs).
+- [ ] Parity sheet complete for B/C train+eval (A′ column planned); every
+      discrepancy classified fatal / by-design / unknown.
+- [ ] If any fatal: B/C re-evaluated under the fixed harness; corrected
+      numbers + per-task breakdown recorded; `VLSP.md` §12 amended.
+- [ ] Training σ_v distribution extracted and archived (unblocks E0-d).
+- [ ] `VLSP_EVAL_PARITY.md` committed; parent pointer bumped.
+
+**Verdict semantics** (unchanged from the execution plan): any fatal mismatch
+⇒ prior B/C behavioral conclusions drop to "unverified" until reproduced under
+the fixed harness; no mismatch ⇒ B/C behavior differences are admissible
+evidence for Phases 1–2.

--- a/VLSP_RUN1_ANALYSIS.md
+++ b/VLSP_RUN1_ANALYSIS.md
@@ -1,0 +1,150 @@
+# VLSP Run 1 — Failure Analysis & Next Steps
+# (第一次实验分析 + 下一步步骤)
+
+**Status:** post-mortem of the first real training runs; defines the mandatory
+diagnostics and the Run-2 plan (R1–R3). Referenced from `VLSP.md` §12.
+
+- Runs analyzed: `vlsp_source_condition_goal_20260629_183112` (24k iters),
+  `vlsp_source_only_goal_20260701_125625` (26k iters) — LIBERO-goal,
+  `mode=video_prior_sample`, **no regularization** (`kl_weight=0`).
+- Data: `source_cond_vs_source_only_metrics_20260704/` (train scalars, stdout,
+  device monitor, plots.html) + rollout videos
+  (e.g. `episode20_failure_open_the_middle_drawer_of_the_cabinet.mp4`).
+
+## 1. Symptom
+
+Every eval rollout executes the **same fixed action sequence, unrelated to the
+task**, for both source-only (B) and source+cond (C).
+
+## 2. Evidence (from training scalars)
+
+| metric | source_cond @18.2k–24k | source_only @0.2k–26.3k | reading |
+|---|---|---|---|
+| `source/logstd_mean` | **-5.0 pinned** (== `logstd_min`) | -3.44 → **-5.0** | **variance collapse to the clamp floor**; σ = e⁻⁵ ≈ 0.0067 (`std_mean` = 0.00674 matches exactly) |
+| `source/source_vs_x0_mse` | 0.79 → **0.91 (rising)** | 0.65 → 0.81 | mu did **NOT** collapse onto x0; it is *worse than predicting the dataset mean* (Var[x0] ≈ 0.55) |
+| `loss/flow` | 0.006–0.03 | 5.48 → 0.016 | tiny — because the target `u = mu(video) − x0` became **deterministic/predictable**, not because the model learned |
+| `source/mu_std` (global) | ≈ 0.61 | 0.17 → 0.63 | **inconclusive by design**: global std over `[B,HA,A]` cannot distinguish "mu varies with the video" from "one fixed trajectory for every video" (metric blind spot, fixed in Run 2) |
+
+The earlier *"10× faster convergence in the first 1k iters"* was this collapse
+in progress — the flow target got easier; nothing was learned faster. This is
+exactly why §11 forbids comparing runs on the raw flow loss.
+
+## 3. Root-cause chain (working hypothesis)
+
+1. **Variance collapse (confirmed).** With `kl_weight=0`, source noise adds
+   irreducible variance to the regression target `u = s − x0`; gradient descent
+   therefore drives `logstd` to the clamp floor. The source becomes a per-input
+   **Dirac**; flow matching degenerates into deterministic pair regression and
+   loses the Gaussian source's "noise-dominated ⇒ always in-distribution at
+   t≈1" robustness.
+2. **Input-independence of the prior (suspected, now testable).** In
+   source+cond there is **no loss pressure for mu to carry video information**
+   — the DiT sees the video via cross-attention anyway; the loss only needs
+   `u = mu − x0` to be *predictable*, and a **constant mu is maximally
+   predictable**. `source_vs_x0_mse > Var[x0]` (an arbitrary offset trajectory,
+   not even the mean) is consistent with this. A constant-mu Dirac source fully
+   explains "fixed action, task-independent" for source-only.
+3. **Eval-side second leg (to be separated by diagnostics).** For source+cond
+   the DiT's condition pathway should still inject task info *if* the velocity
+   field and eval inputs are healthy — so either the prior is constant (2.) AND
+   the field off-manifold behaviour dominates, or the eval inputs
+   (generated-video hidden states at the chosen `stop_video_denoising_step` /
+   checkpoint-loading) are also degenerate. The diagnostics below separate
+   these without retraining.
+
+## 4. Three cheap diagnostics (run BEFORE any retraining)
+
+**D1 — checkpoint / eval-loading audit (minutes, CPU).**
+```bash
+cd mimic-video/model
+python -m scripts.vlsp_probe_prior --ckpt /path/to/checkpoints/.../model/iter_000024000.pt
+```
+The `D1` section confirms `source_prior.*` keys exist (if absent, eval ran a
+randomly initialized prior — mu≡0 → constant near-mean actions — and the
+training run is not even implicated). Also grep the eval log for
+`Loaded source_prior from checkpoint` vs `randomly initialized`.
+
+**D2 — prior degeneration probe (same command, no sim).**
+The same script loads the trained prior net (architecture auto-inferred from
+checkpoint shapes) and feeds K different video latents:
+- `logstd floor fraction ≈ 1.0` → variance collapse confirmed (expected);
+- `cross-input mu diff ≈ 0` → **prior ignores its input** → training-time
+  degeneration confirmed; eval OOD is moot;
+- mu clearly input-sensitive → suspect eval inputs / loading instead.
+Synthetic latents are conclusive only for the "ignores input" verdict; for the
+full answer re-run with real latents:
+```bash
+python -m scripts.vlsp_probe_prior --ckpt ... --latents real_latents.pt   # [K, N, D]
+```
+(dump `crossattn_emb` for a few different tasks from the eval pipeline or a
+data-loader loop into `real_latents.pt`).
+
+**D3 — eval-condition sweep with the EXISTING checkpoint (no retrain).**
+```bash
+# later stop step = cleaner video latent; does the action become task-dependent?
+for STOP in 5 15 25 35; do
+  python -m eval.libero.run --vam-stop-video-denoising-step $STOP ... 
+done
+```
+If actions become task-dependent at late stop steps → the eval-time sigma /
+generated-video gap is a major factor; if they stay fixed regardless → the
+Dirac collapse alone is fatal. (Also record which stop step Run 1 actually
+used.)
+
+## 5. Run 2 plan: R1–R3 (all source+cond, same seed/data/eval as Run 1)
+
+| Run | registered experiment | config delta | rationale |
+|---|---|---|---|
+| **R1** (primary) | `vlsp_r1_kl_1e3` | `kl_weight=1e-3` | KL pins q(s\|video) near N(0,1): kills the σ→0 gradient incentive; source stays a "hint" |
+| **R2** (structural fallback) | `vlsp_r2_blend_050` | `video_prior_blend`, `blend_alpha=0.5`, `kl_weight=1e-3` | source = α·s_video + √(1−α²)·ε keeps an **un-collapsible 0.87-std Gaussian component**; worst-case degeneration = baseline, not a broken model — also covers the "mu carries no info" worst case |
+| **R3** (robustness) | `vlsp_r3_kl_dropout_020` | R1 + `source_dropout_prob=0.2` | DiT sees pure-Gaussian sources 20% of the time → keeps a noise-robust mode |
+
+All three enable the new **sampled-MSE training probe**
+(`model.config.sampled_mse_probe_interval=500`), which logs
+`probe/sampled_action_mse_gtvid` — a scale-invariant, source-independent metric
+(LIBERO has `run_validation=False`, so Run 1 was blind between flow-loss and
+sim eval).
+
+**In-training gates (check at ~2k, 5k, 10k iters):**
+- `source/logstd_mean` must stay > −2.5 (a `[VLSP]`-tagged warning fires
+  otherwise, every 1k iters);
+- `source/logstd_floor_frac` (new) must stay ≈ 0;
+- `source/mu_batch_std` (new, cross-batch) must stay clearly > 0 — this is the
+  metric that would have exposed Run 1's input-independent prior;
+- `probe/sampled_action_mse_gtvid` must trend **down** and beat/track the
+  baseline's value at the same iteration.
+
+**Go/no-go:**
+- R1 healthy → it becomes the main line; proceed to §11 Phase-3 negative
+  controls (shuffled source) before any sweeps.
+- R1 collapses again (logstd → floor despite KL) → raise `kl_weight` to `1e-2`
+  or adopt R2 as the main line; if only R2 is healthy, the conclusion is "this
+  backbone needs an explicit Gaussian component in the source".
+- Everything unhealthy on the probe while D2 said the prior is fine → the
+  problem is the eval/conditioning distribution, not the source: revisit D3
+  (stop-step) before touching the prior again.
+- `source_only` (B) and all sweeps stay **on hold** until a source+cond config
+  passes these gates.
+
+**Launch (same base as Run 1, e.g. goal suite):**
+```bash
+torchrun --nproc_per_node=4 -m scripts.train \
+  --config=cosmos_predict2/configs/config.py -- experiment=vlsp_r1_kl_1e3
+# likewise: experiment=vlsp_r2_blend_050 | experiment=vlsp_r3_kl_dropout_020
+# equivalent ad-hoc overrides, if using suite-specific experiment names:
+#   model.config.pipe_config.action_source_prior.kl_weight=1e-3 \
+#   model.config.sampled_mse_probe_interval=500
+```
+
+## 6. Code added for this plan (all in this repo)
+
+- `model/cosmos_predict2/models/action_source_prior.py` — new metrics
+  `source/mu_batch_std` (cross-batch input-sensitivity; fixes the Run-1 blind
+  spot) and `source/logstd_floor_frac` (collapse alarm).
+- `model/cosmos_predict2/models/world2action_model.py` — `[VLSP]` collapse
+  warning (logstd_mean < −2.5, throttled); `sampled_mse_probe_interval` config
+  + `probe/sampled_action_mse_gtvid` training probe (full sampling on the train
+  batch, unnormalized MSE, DDP/FSDP-safe collective).
+- `model/cosmos_predict2/configs/experiment/world2action.py` — registered
+  `vlsp_r1_kl_1e3`, `vlsp_r2_blend_050`, `vlsp_r3_kl_dropout_020` (probe on).
+- `model/scripts/vlsp_probe_prior.py` — offline D1/D2 diagnostics (CPU).

--- a/eval/libero/aggregate_results.py
+++ b/eval/libero/aggregate_results.py
@@ -1,0 +1,102 @@
+"""Aggregate sharded LIBERO eval summaries written by run.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_rank_summaries(results_dir: Path) -> list[dict[str, Any]]:
+    summaries = []
+    for path in sorted(results_dir.glob("summary.rank*.json")):
+        with path.open("r", encoding="utf-8") as f:
+            summary = json.load(f)
+        summary["_path"] = str(path)
+        summaries.append(summary)
+    if not summaries:
+        raise FileNotFoundError(f"No summary.rank*.json files found in {results_dir}")
+    return summaries
+
+
+def aggregate(results_dir: Path) -> dict[str, Any]:
+    rank_summaries = _load_rank_summaries(results_dir)
+    episodes: dict[str, dict[str, Any]] = {}
+    duplicate_episode_ids: list[str] = []
+
+    for rank_summary in rank_summaries:
+        for episode_id, episode in rank_summary["episodes"].items():
+            if episode_id in episodes:
+                duplicate_episode_ids.append(episode_id)
+                continue
+            episodes[episode_id] = episode
+
+    if duplicate_episode_ids:
+        dupes = ", ".join(sorted(duplicate_episode_ids, key=int)[:20])
+        raise RuntimeError(f"Duplicate episode ids across rank summaries: {dupes}")
+
+    expected_total = max(int(s.get("expected_total_episodes", 0)) for s in rank_summaries)
+    if expected_total <= 0:
+        expected_total = max((int(k) for k in episodes), default=0)
+    missing_episode_ids = [idx for idx in range(1, expected_total + 1) if str(idx) not in episodes]
+
+    per_task: dict[str, dict[str, Any]] = {}
+    for episode in episodes.values():
+        task_id = str(episode["task_id"])
+        bucket = per_task.setdefault(
+            task_id,
+            {
+                "task_id": episode["task_id"],
+                "task": episode["task"],
+                "episodes": 0,
+                "successes": 0,
+            },
+        )
+        bucket["episodes"] += 1
+        bucket["successes"] += int(bool(episode["success"]))
+    for bucket in per_task.values():
+        bucket["success_rate"] = bucket["successes"] / max(bucket["episodes"], 1)
+
+    successes = sum(int(bool(ep["success"])) for ep in episodes.values())
+    return {
+        "schema_version": 1,
+        "results_dir": str(results_dir),
+        "rank_summary_files": [s["_path"] for s in rank_summaries],
+        "ranks_present": sorted(int(s["rank"]) for s in rank_summaries),
+        "world_size": max(int(s["world_size"]) for s in rank_summaries),
+        "task_suite_name": rank_summaries[0]["task_suite_name"],
+        "expected_total_episodes": expected_total,
+        "total_episodes": len(episodes),
+        "missing_episode_ids": missing_episode_ids,
+        "successes": successes,
+        "success_rate": successes / max(len(episodes), 1),
+        "per_task": per_task,
+        "episodes": dict(sorted(episodes.items(), key=lambda item: int(item[0]))),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", required=True, type=Path, help="Path to results/<run_label>/<suite>")
+    args = parser.parse_args()
+
+    summary = aggregate(args.dir)
+    output_path = args.dir / "summary.json"
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, sort_keys=True)
+
+    print(f"Wrote {output_path}")
+    print(
+        "success_rate={:.3f} successes={} episodes={} expected={} missing={}".format(
+            summary["success_rate"],
+            summary["successes"],
+            summary["total_episodes"],
+            summary["expected_total_episodes"],
+            len(summary["missing_episode_ids"]),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/libero/run.py
+++ b/eval/libero/run.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import pathlib
 import random
+import re
+import subprocess
 from collections import deque
 from collections.abc import Iterable
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
+from typing import Any
 
+import attrs
 import imageio
 import numpy as np
 import torch
@@ -18,6 +24,7 @@ import tyro
 from einops import rearrange
 from libero.libero import benchmark, get_libero_path
 from libero.libero.envs import OffScreenRenderEnv
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from scipy.spatial.transform import Rotation
 
 from cosmos_predict2.configs.config import make_config
@@ -38,6 +45,350 @@ CAMERA_HEIGHT = 480
 CAMERA_WIDTH = 640
 
 DUMMY_ACTION = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]
+
+EPISODE_RE = re.compile(r"^episode(?P<episode_id>\d+)_(?P<status>success|failure)_.*\.mp4$")
+
+
+def _short_exp(name: str, keep: int = 40) -> str:
+    if len(name) <= keep:
+        return name
+    return f"{name[:keep]}~{hashlib.sha1(name.encode()).hexdigest()[:8]}"
+
+
+def _sha256_file(path: pathlib.Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_size(path: pathlib.Path) -> int | None:
+    return path.stat().st_size if path.is_file() else None
+
+
+def _git_commit() -> str | None:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        commit = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    # A dirty worktree means the recorded commit does NOT fully describe the
+    # code that produced these rollouts; flag it so the audit cannot silently
+    # trust it (and so the soft resume-time check below can spot code drift).
+    try:
+        dirty = subprocess.check_output(
+            ["git", "-C", str(repo_root), "status", "--porcelain"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        dirty = ""
+    return f"{commit}-dirty" if dirty else commit
+
+
+def _atomic_write_json(path: pathlib.Path, payload: Any) -> None:
+    """Write JSON via a per-pid temp file + rename so a concurrent reader (e.g.
+    another rank's guard) never observes a half-written file. The temp name does
+    not match the ``*.json`` globs used to discover echoes/summaries."""
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    tmp_path.replace(path)
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, (DictConfig, ListConfig)):
+        return _jsonable(OmegaConf.to_container(value, resolve=True))
+    if attrs.has(value.__class__):
+        return _jsonable(attrs.asdict(value))
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, pathlib.Path):
+        return str(value)
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if callable(value):
+        module = getattr(value, "__module__", None)
+        qualname = getattr(value, "__qualname__", None) or repr(value)
+        return f"<callable {module + '.' if module else ''}{qualname}>"
+    if hasattr(value, "__dict__"):
+        return {
+            str(k): _jsonable(v)
+            for k, v in vars(value).items()
+            if not k.startswith("_") and isinstance(v, (str, int, float, bool, pathlib.Path, dict, list, tuple))
+        }
+    return str(value)
+
+
+def _make_run_label(
+    *,
+    vam_experiment_name: str,
+    vam_action_model_path: pathlib.Path,
+    vam_stop_video_denoising_step: int,
+    vam_num_execute_actions: int,
+    seed: int,
+) -> str:
+    return (
+        f"{_short_exp(vam_experiment_name)}_{vam_action_model_path.stem}"
+        f"_stopafter{vam_stop_video_denoising_step}_execute{vam_num_execute_actions}"
+        f"_seed{seed}"
+    )
+
+
+def _index_existing_rollouts(rollout_dir: pathlib.Path) -> dict[int, tuple[pathlib.Path, bool]]:
+    indexed: dict[int, tuple[pathlib.Path, bool]] = {}
+    for path in rollout_dir.glob("episode*.mp4"):
+        match = EPISODE_RE.match(path.name)
+        if match is None:
+            continue
+        episode_id = int(match.group("episode_id"))
+        success = match.group("status") == "success"
+        if episode_id in indexed:
+            prev_path, _ = indexed[episode_id]
+            raise RuntimeError(f"Duplicate rollout files for episode {episode_id}: {prev_path} and {path}")
+        indexed[episode_id] = (path, success)
+    return indexed
+
+
+# CLI-derived invariants that gate whether two runs may share a results dir.
+# Kept separate so the fail-fast pre-check (before the slow model load) can be
+# computed from CLI args alone; the full check adds checkpoint hashes + resolved
+# config in _config_invariants once the model is loaded.
+_CLI_INVARIANT_KEYS = (
+    "vam_experiment_name",
+    "vam_video_model_path",
+    "vam_action_model_path",
+    "vam_dataset_statistics_path",
+    "vam_stop_video_denoising_step",
+    "vam_num_execute_actions",
+    "vam_img_horizon",
+    "vam_lowdim_horizon",
+    "task_suite_name",
+    "num_trials_per_task",
+    "eval_world_size",
+    "num_steps_wait",
+    "seed",
+)
+
+
+def _cli_invariants(cli_args: dict[str, Any]) -> dict[str, Any]:
+    return {key: cli_args.get(key) for key in _CLI_INVARIANT_KEYS}
+
+
+def _config_invariants(echo: dict[str, Any]) -> dict[str, Any]:
+    """Hard invariants: any mismatch means the two runs are NOT comparable and
+    must not share a results dir (raises). Code-version drift is checked
+    separately and softly (see ``_soft_invariants``)."""
+    cli = echo["cli_args"]
+    artifacts = echo["artifacts"]
+    resolved = echo.get("resolved_config") or {}
+    source_prior = resolved.get("action_source_prior") or {}
+    conditioning = resolved.get("action_conditioning") or {}
+    return {
+        "vam_experiment_name": cli["vam_experiment_name"],
+        "vam_video_model_path": artifacts["video_model"]["path"],
+        "vam_video_model_sha256": artifacts["video_model"]["sha256"],
+        "vam_action_model_path": artifacts["action_model"]["path"],
+        "vam_action_model_sha256": artifacts["action_model"]["sha256"],
+        "vam_dataset_statistics_path": artifacts["dataset_statistics"]["path"],
+        "vam_dataset_statistics_sha256": artifacts["dataset_statistics"]["sha256"],
+        "vam_stop_video_denoising_step": cli["vam_stop_video_denoising_step"],
+        "vam_num_execute_actions": cli["vam_num_execute_actions"],
+        "vam_img_horizon": cli["vam_img_horizon"],
+        "vam_lowdim_horizon": cli["vam_lowdim_horizon"],
+        "task_suite_name": cli["task_suite_name"],
+        "num_trials_per_task": cli["num_trials_per_task"],
+        "eval_world_size": cli["eval_world_size"],
+        "num_steps_wait": cli.get("num_steps_wait"),
+        "seed": cli["seed"],
+        # Resolved-config fields that change behaviour: a wrong --vam_experiment_name
+        # (P0-3) flips these even when the CLI paths look identical.
+        "source_prior_enabled": source_prior.get("enabled"),
+        "source_prior_mode": source_prior.get("mode"),
+        "action_conditioning_mode": conditioning.get("mode"),
+        "scheduler_num_denoising_steps": resolved.get("scheduler_num_denoising_steps"),
+        "xattn_layer_idx": resolved.get("xattn_layer_idx"),
+    }
+
+
+def _soft_invariants(echo: dict[str, Any]) -> dict[str, Any]:
+    """Recorded and warned-on but non-fatal: code version can legitimately differ
+    between resumes (an unrelated commit) yet still changes the sampler, so it is
+    surfaced loudly rather than either ignored or made a hard blocker."""
+    return {"git_commit": (echo.get("git") or {}).get("commit")}
+
+
+def _load_existing_echoes(rollout_dir: pathlib.Path) -> list[tuple[pathlib.Path, dict[str, Any]]]:
+    echoes: list[tuple[pathlib.Path, dict[str, Any]]] = []
+    for existing_path in sorted(rollout_dir.glob("config_echo.rank*.json")):
+        try:
+            with existing_path.open("r", encoding="utf-8") as f:
+                echoes.append((existing_path, json.load(f)))
+        except (json.JSONDecodeError, OSError):
+            # Concurrently-written or truncated echo: skip it. Atomic writes mean
+            # a complete file appears under this name shortly, and the writing
+            # rank runs its own full check.
+            continue
+    return echoes
+
+
+def _precheck_cli_invariants(rollout_dir: pathlib.Path, cli_args: dict[str, Any]) -> None:
+    """Fail-fast guard run BEFORE the (minutes-long) model load.
+
+    Compares only CLI-derived invariants (no checkpoint hashing, no model) so a
+    wrong ``--vam_experiment_name`` / stop step / seed pointed at a populated
+    results dir raises immediately. The full guard (checkpoint sha256 + resolved
+    config) still runs in ``_write_config_echo`` once the model is loaded.
+    """
+    current = _cli_invariants(cli_args)
+    for existing_path, existing_echo in _load_existing_echoes(rollout_dir):
+        existing_cli = existing_echo.get("cli_args") or {}
+        existing = {key: existing_cli.get(key) for key in _CLI_INVARIANT_KEYS}
+        if existing != current:
+            raise RuntimeError(
+                "Existing rollout directory was created with different CLI eval "
+                "invariants (fail-fast pre-check).\n"
+                f"Directory: {rollout_dir}\n"
+                f"Existing echo: {existing_path}\n"
+                f"Existing: {json.dumps(existing, indent=2, sort_keys=True)}\n"
+                f"Current: {json.dumps(current, indent=2, sort_keys=True)}"
+            )
+
+
+def _write_config_echo(
+    *,
+    rollout_dir: pathlib.Path,
+    eval_rank: int,
+    cli_args: dict[str, Any],
+    policy: "VAMInference",
+) -> None:
+    world2action_config = policy.model.world2action_pipeline.config
+    action_model_path = pathlib.Path(cli_args["vam_action_model_path"])
+    video_model_path = pathlib.Path(cli_args["vam_video_model_path"])
+    stats_path = pathlib.Path(cli_args["vam_dataset_statistics_path"])
+    echo = {
+        "schema_version": 1,
+        "cli_args": _jsonable(cli_args),
+        "resolved_config": {
+            "action_source_prior": _jsonable(world2action_config.action_source_prior),
+            "action_conditioning": _jsonable(world2action_config.action_conditioning),
+            "ema": {
+                "enabled": bool(world2action_config.ema.enabled),
+                "rate": _jsonable(getattr(world2action_config.ema, "rate", None)),
+            },
+            "weights_loaded": "reg",
+            "scheduler": _jsonable(world2action_config.scheduler),
+            "scheduler_num_denoising_steps": int(world2action_config.scheduler.num_denoising_steps),
+            "xattn_layer_idx": int(world2action_config.xattn_layer_idx),
+        },
+        "artifacts": {
+            "video_model": {
+                "path": str(video_model_path),
+                "size_bytes": _file_size(video_model_path),
+                "sha256": _sha256_file(video_model_path),
+            },
+            "action_model": {
+                "path": str(action_model_path),
+                "size_bytes": _file_size(action_model_path),
+                "sha256": _sha256_file(action_model_path),
+            },
+            "dataset_statistics": {
+                "path": str(stats_path),
+                "size_bytes": _file_size(stats_path),
+                "sha256": _sha256_file(stats_path),
+            },
+        },
+        "git": {"commit": _git_commit()},
+        "audit_notes": {
+            "weights_loaded": "reg",
+            "action_obs_dropout_eval": 0.0,
+            "video_num_sampling_steps": policy.num_sampling_steps,
+            "seed_policy": "World2ActionPipeline is called without a seed override; default seed=0 per policy query.",
+        },
+    }
+    current_invariants = _config_invariants(echo)
+    current_soft = _soft_invariants(echo)
+    for existing_path, existing_echo in _load_existing_echoes(rollout_dir):
+        existing_invariants = _config_invariants(existing_echo)
+        if existing_invariants != current_invariants:
+            raise RuntimeError(
+                "Existing rollout directory was created with different eval invariants.\n"
+                f"Directory: {rollout_dir}\n"
+                f"Existing echo: {existing_path}\n"
+                f"Existing invariants: {json.dumps(existing_invariants, indent=2, sort_keys=True)}\n"
+                f"Current invariants: {json.dumps(current_invariants, indent=2, sort_keys=True)}"
+            )
+        existing_soft = _soft_invariants(existing_echo)
+        if existing_soft != current_soft:
+            print(
+                "[VLSP-EVAL-AUDIT][WARN] resuming into a results dir written by a "
+                f"different code version: existing {existing_soft} vs current "
+                f"{current_soft} ({existing_path}). Success numbers would mix "
+                "sampler versions; start a fresh dir if that matters."
+            )
+
+    echo_path = rollout_dir / f"config_echo.rank{eval_rank}.json"
+    _atomic_write_json(echo_path, echo)
+    print(f"[VLSP-EVAL-AUDIT] {json.dumps(current_invariants, sort_keys=True)}")
+
+
+def _write_rank_summary(
+    *,
+    rollout_dir: pathlib.Path,
+    eval_rank: int,
+    eval_world_size: int,
+    task_suite_name: str,
+    num_tasks: int,
+    num_trials_per_task: int,
+    episodes: dict[int, dict[str, Any]],
+) -> None:
+    per_task: dict[str, dict[str, Any]] = {}
+    for episode in episodes.values():
+        task_id = str(episode["task_id"])
+        bucket = per_task.setdefault(
+            task_id,
+            {
+                "task_id": episode["task_id"],
+                "task": episode["task"],
+                "episodes": 0,
+                "successes": 0,
+            },
+        )
+        bucket["episodes"] += 1
+        bucket["successes"] += int(bool(episode["success"]))
+    for bucket in per_task.values():
+        bucket["success_rate"] = bucket["successes"] / max(bucket["episodes"], 1)
+
+    successes = sum(int(bool(ep["success"])) for ep in episodes.values())
+    summary = {
+        "schema_version": 1,
+        "rank": eval_rank,
+        "world_size": eval_world_size,
+        "task_suite_name": task_suite_name,
+        "num_tasks": num_tasks,
+        "num_trials_per_task": num_trials_per_task,
+        "expected_total_episodes": num_tasks * num_trials_per_task,
+        "episodes": {str(k): v for k, v in sorted(episodes.items())},
+        "total_episodes": len(episodes),
+        "successes": successes,
+        "success_rate": successes / max(len(episodes), 1),
+        "per_task": per_task,
+    }
+    summary_path = rollout_dir / f"summary.rank{eval_rank}.json"
+    _atomic_write_json(summary_path, summary)
 
 
 def set_seed_everywhere(seed: int) -> None:
@@ -316,11 +667,35 @@ def eval_vam_libero(
 ) -> None:
     set_seed_everywhere(seed)
 
-    run_label = (
-        f"{vam_action_model_path.stem}_stopafter{vam_stop_video_denoising_step}_execute{vam_num_execute_actions}"
+    run_label = _make_run_label(
+        vam_experiment_name=vam_experiment_name,
+        vam_action_model_path=vam_action_model_path,
+        vam_stop_video_denoising_step=vam_stop_video_denoising_step,
+        vam_num_execute_actions=vam_num_execute_actions,
+        seed=seed,
     )
     rollout_dir = Path("./results") / run_label / task_suite_name
     rollout_dir.mkdir(parents=True, exist_ok=True)
+
+    cli_args = {
+        "vam_experiment_name": vam_experiment_name,
+        "vam_video_model_path": vam_video_model_path,
+        "vam_action_model_path": str(vam_action_model_path),
+        "vam_dataset_statistics_path": str(vam_dataset_statistics_path),
+        "vam_img_horizon": vam_img_horizon,
+        "vam_lowdim_horizon": vam_lowdim_horizon,
+        "vam_stop_video_denoising_step": vam_stop_video_denoising_step,
+        "vam_num_execute_actions": vam_num_execute_actions,
+        "task_suite_name": task_suite_name,
+        "num_trials_per_task": num_trials_per_task,
+        "eval_rank": eval_rank,
+        "eval_world_size": eval_world_size,
+        "num_steps_wait": num_steps_wait,
+        "seed": seed,
+    }
+    # Fail-fast BEFORE the (minutes-long) model load: catch a wrong experiment /
+    # ckpt / stop step / seed pointed at a populated results dir immediately.
+    _precheck_cli_invariants(rollout_dir, cli_args)
 
     policy = VAMInference(
         vam_experiment_name,
@@ -333,6 +708,15 @@ def eval_vam_libero(
         vam_num_execute_actions,
         rollout_dir,
     )
+    # Full guard now that the resolved config is available (adds checkpoint
+    # sha256 + source/condition mode + scheduler steps to the pre-check above).
+    _write_config_echo(
+        rollout_dir=rollout_dir,
+        eval_rank=eval_rank,
+        cli_args=cli_args,
+        policy=policy,
+    )
+    existing_rollouts = _index_existing_rollouts(rollout_dir)
 
     benchmark_dict = benchmark.get_benchmark_dict()
     if task_suite_name not in benchmark_dict:
@@ -342,8 +726,10 @@ def eval_vam_libero(
 
     max_steps = LIBERO_SUITE_MAX_STEPS[task_suite_name]
 
-    total_episodes = 0
-    total_successes = 0
+    global_episode_id = 0
+    rank_episodes = 0
+    rank_successes = 0
+    rank_episode_results: dict[int, dict[str, Any]] = {}
 
     for task_id in tqdm.tqdm(range(num_tasks), desc="Tasks"):
         task = task_suite.get_task(task_id)
@@ -358,21 +744,26 @@ def eval_vam_libero(
 
         try:
             for episode_idx in tqdm.tqdm(range(num_trials_per_task), desc="Episodes", leave=False):
-                task_episodes += 1
-                total_episodes += 1
+                global_episode_id += 1
 
-                if total_episodes % eval_world_size != eval_rank:
+                if global_episode_id % eval_world_size != eval_rank:
                     continue
-                should_skip = False
-                for ep in map(str, rollout_dir.iterdir()):
-                    if f"episode{total_episodes}_" not in ep:
-                        continue
-                    should_skip = True
-                    if "success" in ep:
-                        task_successes += 1
-                        total_successes += 1
-                    break
-                if should_skip:
+                task_episodes += 1
+                rank_episodes += 1
+
+                existing_rollout = existing_rollouts.get(global_episode_id)
+                if existing_rollout is not None:
+                    _, success = existing_rollout
+                    task_successes += int(success)
+                    rank_successes += int(success)
+                    rank_episode_results[global_episode_id] = {
+                        "episode_id": global_episode_id,
+                        "task_id": task_id,
+                        "task": task_description,
+                        "trial_idx": episode_idx,
+                        "success": bool(success),
+                        "resumed_from_disk": True,
+                    }
                     continue
 
                 env.reset()
@@ -391,20 +782,29 @@ def eval_vam_libero(
 
                 if success:
                     task_successes += 1
-                    total_successes += 1
+                    rank_successes += 1
 
-                save_rollout_video(
+                mp4_path = save_rollout_video(
                     replay_images,
-                    total_episodes,
+                    global_episode_id,
                     success,
                     task_description,
                     rollout_dir,
                 )
+                existing_rollouts[global_episode_id] = (mp4_path, success)
+                rank_episode_results[global_episode_id] = {
+                    "episode_id": global_episode_id,
+                    "task_id": task_id,
+                    "task": task_description,
+                    "trial_idx": episode_idx,
+                    "success": bool(success),
+                    "resumed_from_disk": False,
+                }
 
-                success_rate = total_successes / max(total_episodes, 1)
+                success_rate = rank_successes / max(rank_episodes, 1)
                 print(
                     f"Task {task_id} | Episode {episode_idx + 1} | Success: {success} "
-                    f"| Total Success Rate: {success_rate:.3f}\n"
+                    f"| Rank Success Rate: {success_rate:.3f}\n"
                 )
         finally:
             env.close()
@@ -412,11 +812,21 @@ def eval_vam_libero(
         task_success_rate = task_successes / max(task_episodes, 1)
         print(f"Task {task_id} success rate: {task_success_rate:.3f}")
 
-    overall_success_rate = total_successes / max(total_episodes, 1)
+    _write_rank_summary(
+        rollout_dir=rollout_dir,
+        eval_rank=eval_rank,
+        eval_world_size=eval_world_size,
+        task_suite_name=task_suite_name,
+        num_tasks=num_tasks,
+        num_trials_per_task=num_trials_per_task,
+        episodes=rank_episode_results,
+    )
+
+    overall_success_rate = rank_successes / max(rank_episodes, 1)
     print(
-        f"Completed {total_episodes} episodes | "
-        f"Total successes: {total_successes} | "
-        f"Overall success rate: {overall_success_rate:.3f}\n"
+        f"Completed {rank_episodes} rank-assigned episodes | "
+        f"Total successes: {rank_successes} | "
+        f"Rank success rate: {overall_success_rate:.3f}\n"
     )
 
 

--- a/model/cosmos_predict2/callbacks/device_monitor.py
+++ b/model/cosmos_predict2/callbacks/device_monitor.py
@@ -109,18 +109,35 @@ class DeviceMonitor(EveryN):
 
         peak_gpu_mem_gb = torch.cuda.max_memory_allocated() / (1024**3)
         peak_gpu_mem_reserved_gb = torch.cuda.max_memory_reserved() / (1024**3)
-        temp = torch.cuda.temperature()
+        try:
+            temp = torch.cuda.temperature()
+        except Exception as e:
+            log.warning(f"Failed to get CUDA temperature with error {e}")
+            temp = 0
         try:
             power = torch.cuda.power_draw()
         except Exception as e:
             log.warning(f"Failed to get power draw with error {e}")
             power = 0
-        util = torch.cuda.utilization()
-        clock = torch.cuda.clock_rate()
+        try:
+            util = torch.cuda.utilization()
+        except Exception as e:
+            log.warning(f"Failed to get CUDA utilization with error {e}")
+            util = 0
+        try:
+            clock = torch.cuda.clock_rate()
+        except Exception as e:
+            log.warning(f"Failed to get CUDA clock rate with error {e}")
+            clock = 0
 
-        memory_info = pynvml.nvmlDeviceGetMemoryInfo(self.handle)
-        nvml_used_gpu_mem_gb = memory_info.used / (1024**3)
-        nvml_free_gpu_mem_gb = memory_info.free / (1024**3)
+        try:
+            memory_info = pynvml.nvmlDeviceGetMemoryInfo(self.handle)
+            nvml_used_gpu_mem_gb = memory_info.used / (1024**3)
+            nvml_free_gpu_mem_gb = memory_info.free / (1024**3)
+        except Exception as e:
+            log.warning(f"Failed to get NVML memory info with error {e}")
+            nvml_used_gpu_mem_gb = 0
+            nvml_free_gpu_mem_gb = 0
 
         prof_data = {
             "cpu_mem_gb": cpu_mem_gb,

--- a/model/cosmos_predict2/callbacks/iter_speed.py
+++ b/model/cosmos_predict2/callbacks/iter_speed.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
 import time
 
 import torch
@@ -38,6 +40,57 @@ class IterSpeed(EveryN):
         self.hit_thres = hit_thres
         self.name = self.__class__.__name__
         self.last_hit_time = time.time()
+        self.scalar_log_path = None
+
+    @staticmethod
+    def _to_scalar(value):
+        if torch.is_tensor(value):
+            if value.numel() != 1:
+                return None
+            return float(value.detach().float().cpu().item())
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
+    def _collect_scalars(self, output_batch: dict[str, Tensor], loss: Tensor, iteration: int) -> dict[str, float]:
+        scalars = {"iteration": float(iteration), "loss": float(loss.detach().float().cpu().item())}
+        for key, value in output_batch.items():
+            scalar = self._to_scalar(value)
+            if scalar is not None:
+                scalars[key] = scalar
+
+        x0_mse = scalars.get("source/source_vs_x0_mse")
+        gaussian_mse = scalars.get("source/source_vs_gaussian_mse")
+        if x0_mse is not None and gaussian_mse is not None:
+            scalars["source/source_vs_gaussian_ratio"] = x0_mse / (gaussian_mse + 1e-8)
+        return scalars
+
+    def _write_scalar_log(self, scalars: dict[str, float]) -> None:
+        if self.scalar_log_path is None:
+            self.scalar_log_path = os.path.join(self.config.job.path_local, "train_scalars.jsonl")
+            os.makedirs(os.path.dirname(self.scalar_log_path), exist_ok=True)
+        with open(self.scalar_log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(scalars, sort_keys=True) + "\n")
+
+    @staticmethod
+    def _format_scalar_summary(scalars: dict[str, float]) -> str:
+        keys = [
+            "loss/flow",
+            "loss/source_prior",
+            "source/source_vs_x0_mse",
+            "source/source_vs_gaussian_mse",
+            "source/source_vs_gaussian_ratio",
+            "source/std_mean",
+            "source/logstd_mean",
+            "source/mu_std",
+            "Var_inst[x_0]",
+        ]
+        parts = []
+        for key in keys:
+            value = scalars.get(key)
+            if value is not None:
+                parts.append(f"{key}={value:.6g}")
+        return " | ".join(parts)
 
     def on_training_step_end(
         self,
@@ -77,6 +130,10 @@ class IterSpeed(EveryN):
         cur_time = time.time()
         iter_speed = (cur_time - self.time) / self.every_n / self.step_size
 
-        log.info(f"{iteration} : iter_speed {iter_speed:.2f} seconds per iteration | Loss: {loss.item():.4f}")
+        scalars = self._collect_scalars(output_batch, loss, iteration)
+        self._write_scalar_log(scalars)
+        scalar_summary = self._format_scalar_summary(scalars)
+        suffix = f" | {scalar_summary}" if scalar_summary else ""
+        log.info(f"{iteration} : iter_speed {iter_speed:.2f} seconds per iteration | Loss: {loss.item():.4f}{suffix}")
 
         self.time = cur_time

--- a/model/cosmos_predict2/callbacks/iter_speed.py
+++ b/model/cosmos_predict2/callbacks/iter_speed.py
@@ -75,14 +75,24 @@ class IterSpeed(EveryN):
     @staticmethod
     def _format_scalar_summary(scalars: dict[str, float]) -> str:
         keys = [
+            "probe/sampled_action_mse_gtvid",
             "loss/flow",
             "loss/source_prior",
+            "loss/source_kl",
             "source/source_vs_x0_mse",
+            "source/source_vs_x0_over_var",
             "source/source_vs_gaussian_mse",
             "source/source_vs_gaussian_ratio",
+            "source/mu_vs_x0_mse",
+            "source/source_vs_mu_mse",
             "source/std_mean",
+            "source/std_min",
             "source/logstd_mean",
+            "source/logstd_floor_frac",
+            "source/logstd_ceiling_frac",
             "source/mu_std",
+            "source/mu_batch_std",
+            "source/mu_horizon_std",
             "Var_inst[x_0]",
         ]
         parts = []

--- a/model/cosmos_predict2/configs/config_world2action.py
+++ b/model/cosmos_predict2/configs/config_world2action.py
@@ -31,9 +31,84 @@ class SchedulerConfig:
 
 @make_freezable
 @attrs.define(slots=False)
+class ActionSourcePriorConfig:
+    """VLSP (Video-Latent Source Prior) configuration.
+
+    Controls how the *source* endpoint of the action flow-matching sampler is
+    produced.  The baseline flow matching uses ``source ~ N(0, I)``; VLSP can
+    instead derive the source from the partially-denoised video latent, i.e.
+    ``source ~ q_phi(s | video_latent, obs, ...)``.
+
+    When ``enabled`` is False the module is a no-op and reproduces the original
+    Gaussian behaviour exactly, so old checkpoints / configs are unaffected.
+    """
+
+    # master switch.  enabled=False => exact baseline Gaussian source.
+    enabled: bool = False
+    # one of the source modes implemented in action_source_prior.py:
+    #   gaussian | video_prior_sample | video_prior_mean | video_prior_residual
+    #   video_prior_blend | video_prior_dropout | shuffled_video_prior
+    #   gt_action_noisy_debug
+    mode: str = "gaussian"
+
+    # ---- prior network architecture ----
+    pool_type: str = "mean"  # mean | attention | perceiver
+    hidden_dim: int = 1024
+    num_perceiver_latents: int = 8
+    num_attention_heads: int = 8
+    mlp_depth: int = 2
+
+    # ---- diagonal Gaussian parameterization ----
+    logstd_min: float = -5.0
+    logstd_max: float = 1.0
+    init_logstd: float = -1.0
+
+    # ---- mode-specific knobs ----
+    residual_scale: float = 1.0  # video_prior_residual
+    blend_alpha: float = 1.0  # video_prior_blend
+    source_dropout_prob: float = 0.0  # video_prior_dropout
+    dropout_granularity: str = "sample"  # sample | trajectory | element
+    sampling_temperature: float = 1.0  # scales the stochastic component
+
+    # ---- inputs to the prior ----
+    detach_video_latents: bool = True
+    use_state: bool = True
+    use_context_timestep: bool = True
+    use_language: bool = False
+
+    # ---- regularization weights (all default off) ----
+    kl_weight: float = 0.0
+    mean_l2_weight: float = 0.0
+    std_reg_weight: float = 0.0
+
+    # ---- debug ----
+    debug_noise_std: float = 0.05
+
+
+@make_freezable
+@attrs.define(slots=False)
+class ActionConditioningConfig:
+    """How the video latent is fed to the action DiT cross-attention.
+
+    This is *independent* of the source prior input so that e.g. the source can
+    be derived from the real video latent while the action decoder receives a
+    zeroed (source-only) or shuffled video condition.
+    """
+
+    # normal | zero_video | shuffled_video | dropout_video
+    mode: str = "normal"
+    dropout_prob: float = 0.0
+
+
+@make_freezable
+@attrs.define(slots=False)
 class World2ActionPipelineConfig:
     precision: str
     scheduler: SchedulerConfig
     net: LazyDict[nn.Module]
     ema: EMAConfig
     xattn_layer_idx: int
+    # VLSP: optional video-latent source prior + action conditioning.
+    # Defaults preserve the original behaviour exactly (disabled / gaussian / normal).
+    action_source_prior: ActionSourcePriorConfig = attrs.field(factory=ActionSourcePriorConfig)
+    action_conditioning: ActionConditioningConfig = attrs.field(factory=ActionConditioningConfig)

--- a/model/cosmos_predict2/configs/dataloading/dataset/transform/libero_to_libero_no_rgb.yaml
+++ b/model/cosmos_predict2/configs/dataloading/dataset/transform/libero_to_libero_no_rgb.yaml
@@ -1,0 +1,19 @@
+data_transforms:
+  - name: CosmosProcessImage
+    targets: [workspace_rgb]
+    resize_sizes: ${policy_io.img_resize_sizes}
+
+  - name: ToRotationMatrix
+    targets: [obs/eef_rot_lowdim]
+
+  - name: RotationMatrixTo6D
+    targets: [action/eef_rot_ref_delta_lowdim, obs/eef_rot_lowdim]
+
+  - name: Concat
+    targets: ${policy_io.concat_groups.action/lowdim_concat}
+    out_key: "action/lowdim_concat"
+  - name: Concat
+    targets: ${policy_io.concat_groups.obs/lowdim_concat}
+    out_key: "obs/lowdim_concat"
+
+source_component_names: {}

--- a/model/cosmos_predict2/configs/dataloading/libero_goal_full_no_rgb.yaml
+++ b/model/cosmos_predict2/configs/dataloading/libero_goal_full_no_rgb.yaml
@@ -1,6 +1,6 @@
 defaults:
   - dataset: libero
-  - policy_io: libero
+  - policy_io: libero_no_rgb
   - _self_
 
 dataset:

--- a/model/cosmos_predict2/configs/dataloading/libero_goal_half.yaml
+++ b/model/cosmos_predict2/configs/dataloading/libero_goal_half.yaml
@@ -5,4 +5,4 @@ defaults:
 
 dataset:
   dataset:
-    data_dir: /path/to/libero_goal_half
+    data_dir: /XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video/data/libero_goal_half

--- a/model/cosmos_predict2/configs/dataloading/libero_object_full_no_rgb.yaml
+++ b/model/cosmos_predict2/configs/dataloading/libero_object_full_no_rgb.yaml
@@ -1,6 +1,6 @@
 defaults:
   - dataset: libero
-  - policy_io: libero
+  - policy_io: libero_no_rgb
   - _self_
 
 dataset:

--- a/model/cosmos_predict2/configs/dataloading/libero_spatial_full_no_rgb.yaml
+++ b/model/cosmos_predict2/configs/dataloading/libero_spatial_full_no_rgb.yaml
@@ -1,6 +1,6 @@
 defaults:
   - dataset: libero
-  - policy_io: libero
+  - policy_io: libero_no_rgb
   - _self_
 
 dataset:

--- a/model/cosmos_predict2/configs/dataloading/policy_io/libero_no_rgb.yaml
+++ b/model/cosmos_predict2/configs/dataloading/policy_io/libero_no_rgb.yaml
@@ -1,0 +1,59 @@
+img_resize_sizes: [480, 640]
+
+policy_io:
+  action:
+    eef_pos_ref_delta_lowdim:
+      horizon: 60
+      normalization_type: ${NormalizationType:VARIANCE}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+    eef_rot_ref_delta_lowdim:
+      horizon: 60
+      normalization_type: ${NormalizationType:IDENTITY}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+    gripper_action_lowdim:
+      horizon: 60
+      normalization_type: ${NormalizationType:VARIANCE}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+  obs:
+    eef_pos_lowdim:
+      horizon: 1
+      normalization_type: ${NormalizationType:VARIANCE}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+    eef_rot_lowdim:
+      horizon: 1
+      normalization_type: ${NormalizationType:IDENTITY}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+    gripper_lowdim:
+      horizon: 1
+      normalization_type: ${NormalizationType:VARIANCE}
+      target_repr: ${LieRepr:ABSOLUTE}
+      target_frequency: 20
+      shift_right_by: 0
+    language_embedding:
+      horizon: 1
+      normalization_type: ${NormalizationType:NONE}
+      target_repr: null
+      target_frequency: null
+      shift_right_by: 0
+
+
+concat_groups:
+  action/lowdim_concat:
+    - action/eef_pos_ref_delta_lowdim
+    - action/eef_rot_ref_delta_lowdim
+    - action/gripper_action_lowdim
+
+  obs/lowdim_concat:
+    - obs/eef_pos_lowdim
+    - obs/eef_rot_lowdim
+    - obs/gripper_lowdim

--- a/model/cosmos_predict2/configs/defaults/world2action_pipe.py
+++ b/model/cosmos_predict2/configs/defaults/world2action_pipe.py
@@ -1,6 +1,11 @@
 from hydra.core.config_store import ConfigStore
 
-from cosmos_predict2.configs.config_world2action import SchedulerConfig, World2ActionPipelineConfig
+from cosmos_predict2.configs.config_world2action import (
+    ActionConditioningConfig,
+    ActionSourcePriorConfig,
+    SchedulerConfig,
+    World2ActionPipelineConfig,
+)
 from cosmos_predict2.configs.defaults.ema import EMAConfig
 from cosmos_predict2.models.text2image_dit import SACConfig
 from cosmos_predict2.models.world2action_dit import World2ActionDIT as VarNoiseWorld2ActionDIT
@@ -53,5 +58,9 @@ def register_pipe() -> None:
                 scheduler=SchedulerConfig(alpha=1.0, beta=1.0, num_denoising_steps=10),
                 net=net,
                 ema=EMAConfig(enabled=False),
+                # VLSP defaults; all scalar sub-fields are overridable from the
+                # experiment / CLI exactly like scheduler.num_denoising_steps.
+                action_source_prior=ActionSourcePriorConfig(),
+                action_conditioning=ActionConditioningConfig(),
             ),
         )

--- a/model/cosmos_predict2/configs/experiment/world2action.py
+++ b/model/cosmos_predict2/configs/experiment/world2action.py
@@ -135,8 +135,19 @@ for video_ckpt, data_config, xattn_layer_idx, lr, bsz in it.product(
 #  `model.config.pipe_config.action_conditioning.*` overrides on the CLI       #
 #  (see VLSP.md).                                                              #
 # --------------------------------------------------------------------------- #
-def _vlsp_variant(*, mode: str, conditioning: str = "normal", enabled: bool | None = None, **prior_kwargs) -> dict:
-    """Build the pipe_config overrides for one VLSP variant."""
+def _vlsp_variant(
+    *,
+    mode: str,
+    conditioning: str = "normal",
+    enabled: bool | None = None,
+    model_config: dict | None = None,
+    **prior_kwargs,
+) -> dict:
+    """Build the pipe_config overrides for one VLSP variant.
+
+    ``model_config`` entries are merged into ``model.config`` (e.g. the
+    ``sampled_mse_probe_interval`` training probe).
+    """
     if enabled is None:
         # gaussian is the only mode that is meaningful with VLSP disabled.
         enabled = mode != "gaussian"
@@ -145,6 +156,7 @@ def _vlsp_variant(*, mode: str, conditioning: str = "normal", enabled: bool | No
     return {
         "action_source_prior": action_source_prior,
         "action_conditioning": {"mode": conditioning},
+        "model_config": model_config or {},
     }
 
 
@@ -171,6 +183,38 @@ VLSP_VARIANTS: dict[str, dict] = {
     "vlsp_residual": _vlsp_variant(mode="video_prior_residual", residual_scale=1.0),
     # debug-only smoke mode
     "vlsp_debug_gt_action_noisy": _vlsp_variant(mode="gt_action_noisy_debug", debug_noise_std=0.05),
+    # ------------------------------------------------------------------ #
+    # Run-2 anti-collapse variants (see VLSP_RUN1_ANALYSIS.md). Run 1
+    # (kl=0, video_prior_sample) collapsed to a Dirac source
+    # (logstd pinned at the -5 floor) => fixed task-independent actions.
+    # All three keep conditioning=normal and enable the sampled-MSE probe.
+    # ------------------------------------------------------------------ #
+    # R1: primary fix — KL keeps sigma near 1 (source stays a "hint").
+    "vlsp_r1_kl_1e3": _vlsp_variant(
+        mode="video_prior_sample",
+        conditioning="normal",
+        kl_weight=1e-3,
+        model_config={"sampled_mse_probe_interval": 500},
+    ),
+    # R2: structural fallback — blend guarantees a sqrt(1-a^2)=0.87-std
+    #     Gaussian component that no optimizer pressure can remove; its
+    #     worst-case degeneration is the baseline, not a broken model.
+    "vlsp_r2_blend_050": _vlsp_variant(
+        mode="video_prior_blend",
+        conditioning="normal",
+        blend_alpha=0.5,
+        kl_weight=1e-3,
+        model_config={"sampled_mse_probe_interval": 500},
+    ),
+    # R3: R1 + per-sample source dropout — the DiT keeps a noise-robust
+    #     mode by seeing pure-Gaussian sources 20% of the time.
+    "vlsp_r3_kl_dropout_020": _vlsp_variant(
+        mode="video_prior_dropout",
+        conditioning="normal",
+        kl_weight=1e-3,
+        source_dropout_prob=0.20,
+        model_config={"sampled_mse_probe_interval": 500},
+    ),
 }
 
 if vlsp_base_cfg is not None:
@@ -180,6 +224,8 @@ if vlsp_base_cfg is not None:
         vlsp_cfg["job"]["name"] = vlsp_name
         vlsp_cfg["model"]["config"]["pipe_config"]["action_source_prior"] = overrides["action_source_prior"]
         vlsp_cfg["model"]["config"]["pipe_config"]["action_conditioning"] = overrides["action_conditioning"]
+        for extra_key, extra_val in overrides.get("model_config", {}).items():
+            vlsp_cfg["model"]["config"][extra_key] = copy.deepcopy(extra_val)
         cs.store(
             group="experiment",
             package="_global_",

--- a/model/cosmos_predict2/configs/experiment/world2action.py
+++ b/model/cosmos_predict2/configs/experiment/world2action.py
@@ -135,12 +135,26 @@ for video_ckpt, data_config, xattn_layer_idx, lr, bsz in it.product(
 #  `model.config.pipe_config.action_conditioning.*` overrides on the CLI       #
 #  (see VLSP.md).                                                              #
 # --------------------------------------------------------------------------- #
+VLSP_DIAG_MODEL_CONFIG: dict = {"sampled_mse_probe_interval": 500}
+VLSP_DIAG_TRAINER_CONFIG: dict = {"logging_iter": 500}
+VLSP_DIAG_CHECKPOINT_CONFIG: dict = {"save_iter": 5_000}
+
+
+def _merge_dicts(base: dict, override: dict | None) -> dict:
+    merged = copy.deepcopy(base)
+    if override:
+        merged.update(override)
+    return merged
+
+
 def _vlsp_variant(
     *,
     mode: str,
     conditioning: str = "normal",
     enabled: bool | None = None,
     model_config: dict | None = None,
+    trainer_config: dict | None = None,
+    checkpoint_config: dict | None = None,
     **prior_kwargs,
 ) -> dict:
     """Build the pipe_config overrides for one VLSP variant.
@@ -156,7 +170,9 @@ def _vlsp_variant(
     return {
         "action_source_prior": action_source_prior,
         "action_conditioning": {"mode": conditioning},
-        "model_config": model_config or {},
+        "model_config": _merge_dicts(VLSP_DIAG_MODEL_CONFIG, model_config),
+        "trainer_config": _merge_dicts(VLSP_DIAG_TRAINER_CONFIG, trainer_config),
+        "checkpoint_config": _merge_dicts(VLSP_DIAG_CHECKPOINT_CONFIG, checkpoint_config),
     }
 
 
@@ -215,6 +231,34 @@ VLSP_VARIANTS: dict[str, dict] = {
         source_dropout_prob=0.20,
         model_config={"sampled_mse_probe_interval": 500},
     ),
+    # ------------------------------------------------------------------ #
+    # Next diagnostic sweep: isolate whether raising the variance floor is
+    # enough, and keep KL/blend controls in the same logging/checkpoint regime.
+    # ------------------------------------------------------------------ #
+    "vlsp_next_floor_m2": _vlsp_variant(
+        mode="video_prior_sample",
+        conditioning="normal",
+        logstd_min=-2.0,
+    ),
+    "vlsp_next_kl_floor_m2": _vlsp_variant(
+        mode="video_prior_sample",
+        conditioning="normal",
+        logstd_min=-2.0,
+        kl_weight=1e-3,
+    ),
+    "vlsp_next_blend050_kl_floor_m2": _vlsp_variant(
+        mode="video_prior_blend",
+        conditioning="normal",
+        blend_alpha=0.5,
+        logstd_min=-2.0,
+        kl_weight=1e-3,
+    ),
+    "vlsp_next_mean_floor_m2": _vlsp_variant(
+        mode="video_prior_mean",
+        conditioning="normal",
+        logstd_min=-2.0,
+        kl_weight=1e-3,
+    ),
 }
 
 if vlsp_base_cfg is not None:
@@ -226,6 +270,10 @@ if vlsp_base_cfg is not None:
         vlsp_cfg["model"]["config"]["pipe_config"]["action_conditioning"] = overrides["action_conditioning"]
         for extra_key, extra_val in overrides.get("model_config", {}).items():
             vlsp_cfg["model"]["config"][extra_key] = copy.deepcopy(extra_val)
+        for extra_key, extra_val in overrides.get("trainer_config", {}).items():
+            vlsp_cfg["trainer"][extra_key] = copy.deepcopy(extra_val)
+        for extra_key, extra_val in overrides.get("checkpoint_config", {}).items():
+            vlsp_cfg["checkpoint"][extra_key] = copy.deepcopy(extra_val)
         cs.store(
             group="experiment",
             package="_global_",

--- a/model/cosmos_predict2/configs/experiment/world2action.py
+++ b/model/cosmos_predict2/configs/experiment/world2action.py
@@ -79,6 +79,11 @@ def get_local_batch_size(global_bsz: int) -> int:
     return int(res)
 
 
+# A representative base experiment used as the foundation for the VLSP variants
+# below. The VLSP variants simply layer source-prior / action-conditioning
+# overrides on top of a concrete (video_ckpt, data_config, pipe, lr, bsz) base.
+vlsp_base_cfg: dict | None = None
+
 for video_ckpt, data_config, xattn_layer_idx, lr, bsz in it.product(
     VIDEO_MODEL_CKPT_NAMES, DATA_CONFIGS.keys(), xattn_layer_idxs, lrs, bszs
 ):
@@ -111,5 +116,75 @@ for video_ckpt, data_config, xattn_layer_idx, lr, bsz in it.product(
         name=exp_name,
         node=cfg,
     )
+
+    # Prefer a libero base for the VLSP variants (cheap to smoke-test); otherwise
+    # fall back to the first valid combination.
+    if vlsp_base_cfg is None or ("libero" in data_config and "libero" not in vlsp_base_cfg["job"]["name"]):
+        vlsp_base_cfg = copy.deepcopy(cfg)
+
+
+# --------------------------------------------------------------------------- #
+#  VLSP experiment variants                                                    #
+#                                                                              #
+#  source prior input  <-- action_source_prior.*                              #
+#  action DiT condition <-- action_conditioning.*  (independent axis)         #
+#                                                                              #
+#  Every variant below is registered on top of `vlsp_base_cfg`. To apply VLSP  #
+#  to a *different* base experiment, just add the same                         #
+#  `model.config.pipe_config.action_source_prior.*` /                          #
+#  `model.config.pipe_config.action_conditioning.*` overrides on the CLI       #
+#  (see VLSP.md).                                                              #
+# --------------------------------------------------------------------------- #
+def _vlsp_variant(*, mode: str, conditioning: str = "normal", enabled: bool | None = None, **prior_kwargs) -> dict:
+    """Build the pipe_config overrides for one VLSP variant."""
+    if enabled is None:
+        # gaussian is the only mode that is meaningful with VLSP disabled.
+        enabled = mode != "gaussian"
+    action_source_prior: dict = {"enabled": enabled, "mode": mode}
+    action_source_prior.update(prior_kwargs)
+    return {
+        "action_source_prior": action_source_prior,
+        "action_conditioning": {"mode": conditioning},
+    }
+
+
+VLSP_VARIANTS: dict[str, dict] = {
+    # A. baseline (exact original behaviour)
+    "vlsp_baseline_gaussian": _vlsp_variant(mode="gaussian", conditioning="normal", enabled=False),
+    "baseline_gaussian": _vlsp_variant(mode="gaussian", conditioning="normal", enabled=False),
+    # B/C. stochastic video-prior source
+    "vlsp_source_only_sample": _vlsp_variant(mode="video_prior_sample", conditioning="zero_video"),
+    "vlsp_source_condition_sample": _vlsp_variant(mode="video_prior_sample", conditioning="normal"),
+    # D/E. deterministic video-prior source
+    "vlsp_source_only_mean": _vlsp_variant(mode="video_prior_mean", conditioning="zero_video"),
+    "vlsp_source_condition_mean": _vlsp_variant(mode="video_prior_mean", conditioning="normal"),
+    # H. blend video source with Gaussian
+    "vlsp_blend_alpha_025": _vlsp_variant(mode="video_prior_blend", blend_alpha=0.25),
+    "vlsp_blend_alpha_050": _vlsp_variant(mode="video_prior_blend", blend_alpha=0.50),
+    "vlsp_blend_alpha_075": _vlsp_variant(mode="video_prior_blend", blend_alpha=0.75),
+    # F/G. negative controls
+    "vlsp_shuffled_source": _vlsp_variant(mode="shuffled_video_prior", conditioning="normal"),
+    "vlsp_shuffled_condition": _vlsp_variant(mode="video_prior_sample", conditioning="shuffled_video"),
+    # J. source dropout / mixture with Gaussian
+    "vlsp_dropout_020": _vlsp_variant(mode="video_prior_dropout", source_dropout_prob=0.20),
+    # I. residual source
+    "vlsp_residual": _vlsp_variant(mode="video_prior_residual", residual_scale=1.0),
+    # debug-only smoke mode
+    "vlsp_debug_gt_action_noisy": _vlsp_variant(mode="gt_action_noisy_debug", debug_noise_std=0.05),
+}
+
+if vlsp_base_cfg is not None:
+    for vlsp_name, overrides in VLSP_VARIANTS.items():
+        vlsp_cfg = copy.deepcopy(vlsp_base_cfg)
+        vlsp_cfg["job"]["group"] = "vlsp"
+        vlsp_cfg["job"]["name"] = vlsp_name
+        vlsp_cfg["model"]["config"]["pipe_config"]["action_source_prior"] = overrides["action_source_prior"]
+        vlsp_cfg["model"]["config"]["pipe_config"]["action_conditioning"] = overrides["action_conditioning"]
+        cs.store(
+            group="experiment",
+            package="_global_",
+            name=vlsp_name,
+            node=vlsp_cfg,
+        )
 
 # TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=7200 CUDA_DEVICE_MAX_CONNECTIONS=1 NVTE_FUSED_ATTN=0 torchrun --nproc_per_node=4 --master_port=12341 -m scripts.train --config=cosmos_predict2/configs/config.py -- experiment=...

--- a/model/cosmos_predict2/data/action/dataset_action.py
+++ b/model/cosmos_predict2/data/action/dataset_action.py
@@ -166,6 +166,8 @@ class MimicDataset(torch.utils.data.Dataset):
             self._threadpool_limits_is_applied = True
 
         data = self._chunk_reader.read_chunk(idx)
+        if not self._should_ignore_transforms_for_norm:
+            data["sample_idx"] = np.array(idx, dtype=np.int64)
 
         return apply_data_transforms(
             data,

--- a/model/cosmos_predict2/models/action_source_prior.py
+++ b/model/cosmos_predict2/models/action_source_prior.py
@@ -278,11 +278,21 @@ class VideoLatentSourcePrior(nn.Module):
             else:
                 h = h + 0.0 * self.time_proj(h.new_zeros((B, self.time_proj.in_features)))
 
-        if self.use_language and language_B_L_D is not None:
-            lang = language_B_L_D
-            if lang.dim() == 3:
-                lang = lang.mean(dim=1)
-            h = h + self.lang_proj(lang.to(h.dtype))
+        if self.use_language:
+            if language_B_L_D is not None:
+                lang = language_B_L_D
+                if lang.dim() == 3:
+                    lang = lang.mean(dim=1)
+                h = h + self.lang_proj(lang.to(h.dtype))
+            elif getattr(self.lang_proj, "has_uninitialized_params", lambda: False)():
+                raise ValueError(
+                    "action_source_prior.use_language=true requires language_B_L_D on the first "
+                    "prior forward so lang_proj can infer the language embedding width."
+                )
+            else:
+                # Keep lang_proj in the autograd graph when a later batch has no
+                # language tensor, so DDP with find_unused_parameters=False is safe.
+                h = h + 0.0 * self.lang_proj(h.new_zeros((B, self.lang_proj.in_features)))
 
         per_step = self.horizon_queries[:, :horizon, :].to(h.dtype) + h.unsqueeze(1)  # [B, HA, hidden]
         per_step = self.trunk(per_step)
@@ -317,6 +327,13 @@ class ActionSourcePrior(nn.Module):
         self.cfg = cfg
         self.action_dim = action_dim
         self.max_horizon = max_horizon
+        if cfg.mode not in ALL_SOURCE_MODES:
+            raise ValueError(f"unknown source_mode: {cfg.mode!r}")
+        if bool(cfg.enabled) and cfg.mode == "gaussian":
+            raise ValueError(
+                "action_source_prior.enabled=true with mode='gaussian' is ambiguous: "
+                "use enabled=false for the exact Gaussian baseline, or choose a video-prior mode."
+            )
 
         self._uses_net = bool(cfg.enabled) and cfg.mode in VIDEO_PRIOR_MODES
         if self._uses_net:

--- a/model/cosmos_predict2/models/action_source_prior.py
+++ b/model/cosmos_predict2/models/action_source_prior.py
@@ -1,0 +1,631 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""VLSP: Video-Latent Source Prior for Action Flow.
+
+Existing mimic-video uses the partially-denoised video latent purely as a
+*condition* for the action DiT.  VLSP additionally uses that latent to define
+the *source* endpoint of the action flow-matching sampler:
+
+    baseline:   source ~ N(0, I)
+    VLSP:       source ~ q_phi(s | h_v, o, ...) = N(mu_phi(h_v), diag(sigma_phi(h_v)^2))
+
+with flow matching
+
+    x_t = (1 - t) * a + t * s
+    u_t = s - a
+    L   = || v_theta(x_t, t, c) - u_t ||^2  +  lambda_KL * KL(q_phi || N(0, I))
+
+This module is intentionally free of transformer-engine / flash-attn imports so
+it can be unit-tested on CPU.  The returned source always lives in the *same
+normalized action space* as ``x0_B_HA_A`` because the action flow loss is
+computed on normalized actions.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from imaginaire.utils import log, misc
+
+if TYPE_CHECKING:
+    # Imported for typing only; keeps this nn.Module importable without dragging
+    # in the hydra / omegaconf config stack (handy for unit tests).
+    from cosmos_predict2.configs.config_world2action import ActionSourcePriorConfig
+
+# Modes that require the learned VideoLatentSourcePrior network.
+VIDEO_PRIOR_MODES: frozenset[str] = frozenset(
+    {
+        "video_prior_sample",
+        "video_prior_mean",
+        "video_prior_residual",
+        "video_prior_blend",
+        "video_prior_dropout",
+        "shuffled_video_prior",
+    }
+)
+
+# All recognised source modes.
+ALL_SOURCE_MODES: frozenset[str] = VIDEO_PRIOR_MODES | frozenset({"gaussian", "gt_action_noisy_debug"})
+
+# Stable integer ids so modes can be logged as scalars.
+SOURCE_MODE_IDS: dict[str, int] = {
+    "gaussian": 0,
+    "video_prior_sample": 1,
+    "video_prior_mean": 2,
+    "video_prior_residual": 3,
+    "video_prior_blend": 4,
+    "video_prior_dropout": 5,
+    "shuffled_video_prior": 6,
+    "gt_action_noisy_debug": 7,
+}
+COND_MODE_IDS: dict[str, int] = {
+    "normal": 0,
+    "zero_video": 1,
+    "shuffled_video": 2,
+    "dropout_video": 3,
+}
+
+
+# --------------------------------------------------------------------------- #
+#  Small building blocks (CPU friendly, no transformer-engine dependency)      #
+# --------------------------------------------------------------------------- #
+class _SinusoidalEmbedding(nn.Module):
+    """Continuous sinusoidal embedding for a scalar (e.g. the video sigma)."""
+
+    def __init__(self, dim: int, min_period: float = 4e-3, max_period: float = 4.0) -> None:
+        super().__init__()
+        if dim % 2 != 0:
+            raise ValueError(f"embedding dim ({dim}) must be even")
+        self.dim = dim
+        self.min_period = min_period
+        self.max_period = max_period
+
+    def forward(self, t_B: torch.Tensor) -> torch.Tensor:
+        # t_B: [B] scalar in [0, 1) (already squashed). Returns [B, dim].
+        fraction = torch.linspace(0.0, 1.0, self.dim // 2, device=t_B.device, dtype=torch.float32)
+        freqs = math.tau / (self.min_period * (self.max_period / self.min_period) ** fraction)
+        ang = t_B.float()[:, None] * freqs[None, :]
+        return torch.cat((torch.sin(ang), torch.cos(ang)), dim=-1)
+
+
+class _MLP(nn.Module):
+    """Residual-free GELU MLP, ``depth`` hidden layers of width ``dim``."""
+
+    def __init__(self, dim: int, depth: int) -> None:
+        super().__init__()
+        layers: list[nn.Module] = [nn.LayerNorm(dim)]
+        for _ in range(max(1, depth)):
+            layers += [nn.Linear(dim, dim), nn.GELU()]
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.net(x)
+
+
+class _MeanPool(nn.Module):
+    """Ordinary (or masked) mean over the token dimension, then project."""
+
+    def __init__(self, dim_in: int, hidden: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(dim_in, hidden)
+
+    def forward(self, x_B_N_D: torch.Tensor, mask_B_N: torch.Tensor | None = None) -> torch.Tensor:
+        if mask_B_N is None:
+            pooled = x_B_N_D.mean(dim=1)
+        else:
+            m = mask_B_N.to(x_B_N_D.dtype)[..., None]
+            pooled = (x_B_N_D * m).sum(dim=1) / m.sum(dim=1).clamp_min(1.0)
+        return self.proj(pooled)
+
+
+class _AttentionPool(nn.Module):
+    """A single learned query attends to the video tokens."""
+
+    def __init__(self, dim_in: int, hidden: int, num_heads: int) -> None:
+        super().__init__()
+        self.kv_proj = nn.Linear(dim_in, hidden)
+        self.query = nn.Parameter(torch.zeros(1, 1, hidden))
+        self.attn = nn.MultiheadAttention(hidden, num_heads, batch_first=True)
+
+    def forward(self, x_B_N_D: torch.Tensor, mask_B_N: torch.Tensor | None = None) -> torch.Tensor:
+        kv = self.kv_proj(x_B_N_D)
+        q = self.query.expand(x_B_N_D.shape[0], -1, -1).to(kv.dtype)
+        key_padding_mask = None if mask_B_N is None else ~mask_B_N
+        out, _ = self.attn(q, kv, kv, key_padding_mask=key_padding_mask, need_weights=False)
+        return out[:, 0]
+
+
+class _PerceiverPool(nn.Module):
+    """A small learned latent array cross-attends to the video tokens."""
+
+    def __init__(self, dim_in: int, hidden: int, num_latents: int, num_heads: int) -> None:
+        super().__init__()
+        self.kv_proj = nn.Linear(dim_in, hidden)
+        self.latents = nn.Parameter(torch.zeros(1, num_latents, hidden))
+        self.attn = nn.MultiheadAttention(hidden, num_heads, batch_first=True)
+        self.ff = _MLP(hidden, depth=1)
+
+    def forward(self, x_B_N_D: torch.Tensor, mask_B_N: torch.Tensor | None = None) -> torch.Tensor:
+        kv = self.kv_proj(x_B_N_D)
+        lat = self.latents.expand(x_B_N_D.shape[0], -1, -1).to(kv.dtype)
+        key_padding_mask = None if mask_B_N is None else ~mask_B_N
+        out, _ = self.attn(lat, kv, kv, key_padding_mask=key_padding_mask, need_weights=False)
+        out = lat + out
+        out = self.ff(out)
+        return out.mean(dim=1)  # pool the latent array
+
+
+# --------------------------------------------------------------------------- #
+#  The learned prior network                                                   #
+# --------------------------------------------------------------------------- #
+class VideoLatentSourcePrior(nn.Module):
+    """Maps (video latent, state, context-timestep[, language]) to a horizon-aware
+    diagonal-Gaussian over the flow-matching source.
+
+    Output ``mu`` / ``logstd`` have shape ``[B, HA, action_dim]``.  The network is
+    horizon-aware: a learned per-step query is broadcast onto the pooled global
+    feature so the prior can differ across action steps rather than blindly
+    broadcasting a single global vector.
+    """
+
+    def __init__(
+        self,
+        cfg: ActionSourcePriorConfig,
+        *,
+        action_dim: int,
+        video_emb_dim: int,
+        state_dim: int,
+        max_horizon: int,
+    ) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.action_dim = action_dim
+        self.max_horizon = max_horizon
+        self.use_state = cfg.use_state
+        self.use_context_timestep = cfg.use_context_timestep
+        self.use_language = cfg.use_language
+        hidden = cfg.hidden_dim
+
+        self.ctx_norm = nn.LayerNorm(video_emb_dim)
+        if cfg.pool_type == "mean":
+            self.pool: nn.Module = _MeanPool(video_emb_dim, hidden)
+        elif cfg.pool_type == "attention":
+            self.pool = _AttentionPool(video_emb_dim, hidden, cfg.num_attention_heads)
+        elif cfg.pool_type == "perceiver":
+            self.pool = _PerceiverPool(video_emb_dim, hidden, cfg.num_perceiver_latents, cfg.num_attention_heads)
+        else:
+            raise ValueError(f"unknown pool_type: {cfg.pool_type!r}")
+
+        if self.use_state:
+            self.state_proj = nn.Linear(state_dim, hidden)
+        if self.use_context_timestep:
+            self.time_embed = _SinusoidalEmbedding(hidden)
+            self.time_proj = nn.Linear(hidden, hidden)
+        if self.use_language:
+            # language embedding width is unknown at construction in the general
+            # case; default off.  A LazyLinear keeps it optional & dim-agnostic.
+            self.lang_proj = nn.LazyLinear(hidden)
+
+        # learned horizon queries -> horizon awareness
+        self.horizon_queries = nn.Parameter(torch.zeros(1, max_horizon, hidden))
+        self.trunk = _MLP(hidden, depth=cfg.mlp_depth)
+        self.mu_head = nn.Linear(hidden, action_dim)
+        self.logstd_head = nn.Linear(hidden, action_dim)
+
+        self.init_weights()
+
+    def init_weights(self) -> None:
+        nn.init.trunc_normal_(self.horizon_queries, std=0.02)
+        # Start close to a standard-ish prior: mean 0, constant logstd = init_logstd.
+        nn.init.zeros_(self.mu_head.weight)
+        nn.init.zeros_(self.mu_head.bias)
+        nn.init.zeros_(self.logstd_head.weight)
+        nn.init.constant_(self.logstd_head.bias, self.cfg.init_logstd)
+
+    @property
+    def _pdtype(self) -> torch.dtype:
+        return self.mu_head.weight.dtype
+
+    def forward(
+        self,
+        crossattn_emb: torch.Tensor,
+        state_B_HO_O: torch.Tensor | None,
+        context_timesteps_B_1: torch.Tensor | None,
+        horizon: int,
+        language_B_L_D: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        # Accept either flattened [B, N, D] or structured [B, T, H, W, D] latents.
+        x = crossattn_emb
+        if x.dim() == 5:
+            b, t, h, w, d = x.shape
+            x = x.reshape(b, t * h * w, d)
+        x = x.to(self._pdtype)
+
+        h = self.pool(self.ctx_norm(x))  # [B, hidden]
+        B = h.shape[0]
+
+        if self.use_state:
+            if state_B_HO_O is not None and state_B_HO_O.shape[1] > 0:
+                h = h + self.state_proj(state_B_HO_O.to(h.dtype).mean(dim=1))
+            else:
+                # keep state_proj in the autograd graph even when no obs are
+                # provided, so DDP (find_unused_parameters=False) is happy.
+                zeros = h.new_zeros((B, self.state_proj.in_features))
+                h = h + 0.0 * self.state_proj(zeros)
+
+        if self.use_context_timestep:
+            if context_timesteps_B_1 is not None:
+                sigma = context_timesteps_B_1.reshape(context_timesteps_B_1.shape[0], -1)[:, 0].float()
+                squashed = sigma / (1.0 + sigma)  # map [0, inf) -> [0, 1)
+                h = h + self.time_proj(self.time_embed(squashed).to(h.dtype))
+            else:
+                h = h + 0.0 * self.time_proj(h.new_zeros((B, self.time_proj.in_features)))
+
+        if self.use_language and language_B_L_D is not None:
+            lang = language_B_L_D
+            if lang.dim() == 3:
+                lang = lang.mean(dim=1)
+            h = h + self.lang_proj(lang.to(h.dtype))
+
+        per_step = self.horizon_queries[:, :horizon, :].to(h.dtype) + h.unsqueeze(1)  # [B, HA, hidden]
+        per_step = self.trunk(per_step)
+        mu = self.mu_head(per_step)
+        logstd = self.logstd_head(per_step).clamp(min=self.cfg.logstd_min, max=self.cfg.logstd_max)
+        return mu, logstd
+
+
+# --------------------------------------------------------------------------- #
+#  Top-level dispatcher                                                        #
+# --------------------------------------------------------------------------- #
+class ActionSourcePrior(nn.Module):
+    """Produces the flow-matching source endpoint for the action sampler.
+
+    ``forward`` returns ``(source_B_HA_A, metrics)`` where ``source`` lives in the
+    normalized action space (float32).  The learned :class:`VideoLatentSourcePrior`
+    is only instantiated when it is actually needed (``enabled`` and a video-prior
+    mode), so disabled / gaussian configs carry no extra parameters and old
+    checkpoints load cleanly.
+    """
+
+    def __init__(
+        self,
+        cfg: ActionSourcePriorConfig,
+        *,
+        action_dim: int,
+        video_emb_dim: int,
+        state_dim: int,
+        max_horizon: int,
+    ) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.action_dim = action_dim
+        self.max_horizon = max_horizon
+
+        self._uses_net = bool(cfg.enabled) and cfg.mode in VIDEO_PRIOR_MODES
+        if self._uses_net:
+            self.net: VideoLatentSourcePrior | None = VideoLatentSourcePrior(
+                cfg,
+                action_dim=action_dim,
+                video_emb_dim=video_emb_dim,
+                state_dim=state_dim,
+                max_horizon=max_horizon,
+            )
+        else:
+            self.net = None
+
+    # ------------------------------------------------------------------ #
+    @property
+    def effective_mode(self) -> str:
+        """The mode actually used; forced to ``gaussian`` when disabled."""
+        return self.cfg.mode if self.cfg.enabled else "gaussian"
+
+    @property
+    def has_trainable_params(self) -> bool:
+        return self.net is not None
+
+    # ------------------------------------------------------------------ #
+    def _gaussian_baseline(
+        self,
+        shape: tuple[int, int, int],
+        device: torch.device,
+        dtype: torch.dtype,
+        training: bool,
+        seed: int | None,
+    ) -> torch.Tensor:
+        """Exactly reproduces the original source draw.
+
+        Training uses ``torch.randn`` (matching ``draw_training_t_and_epsilon``);
+        inference with a seed uses ``misc.arch_invariant_rand`` (matching the old
+        ``World2ActionPipeline.__call__``).
+        """
+        if seed is not None and not training:
+            return misc.arch_invariant_rand(shape, dtype=dtype, device=device, seed=seed)
+        return torch.randn(shape, device=device, dtype=dtype)
+
+    def _make_dropout_mask(
+        self,
+        shape: tuple[int, int, int],
+        keep_prob: float,
+        rand,
+    ) -> torch.Tensor:
+        """Bernoulli(keep_prob) keep-mask broadcastable over ``shape`` = (B, HA, A).
+
+        ``dropout_granularity`` controls the broadcast shape:
+          * ``sample`` / ``trajectory``: one decision per trajectory -> (B, 1, 1)
+          * ``element``: an independent decision per scalar -> (B, HA, A)
+        """
+        b, ha, a = shape
+        granularity = self.cfg.dropout_granularity
+        if granularity in ("sample", "trajectory"):
+            mask_shape: tuple[int, int, int] = (b, 1, 1)
+        elif granularity == "element":
+            mask_shape = (b, ha, a)
+        else:
+            raise ValueError(f"unknown dropout_granularity: {granularity!r}")
+        return rand(mask_shape).lt(keep_prob).float()
+
+    # ------------------------------------------------------------------ #
+    def forward(
+        self,
+        shape: tuple[int, int, int],
+        *,
+        crossattn_emb: torch.Tensor | None,
+        state_B_HO_O: torch.Tensor | None,
+        context_timesteps_B_1: torch.Tensor | None,
+        x0_B_HA_A: torch.Tensor | None = None,
+        language_B_L_D: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+        training: bool = False,
+        seed: int | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        B, HA, A = shape
+        mode = self.effective_mode
+
+        # Resolve device; source lives in float32 (same as the original epsilon/x0).
+        if x0_B_HA_A is not None:
+            device = x0_B_HA_A.device
+        elif crossattn_emb is not None:
+            device = crossattn_emb.device
+        elif state_B_HO_O is not None:
+            device = state_B_HO_O.device
+        else:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        dtype = torch.float32
+
+        # Generator for deterministic, *distinct* gaussian draws inside video modes.
+        gen = generator
+        if gen is None and seed is not None and not training:
+            gen = torch.Generator(device=device)
+            gen.manual_seed(int(seed))
+
+        def randn(shp: tuple[int, ...]) -> torch.Tensor:
+            return torch.randn(shp, device=device, dtype=dtype, generator=gen)
+
+        def rand(shp: tuple[int, ...]) -> torch.Tensor:
+            return torch.rand(shp, device=device, dtype=dtype, generator=gen)
+
+        metrics: dict[str, torch.Tensor] = {}
+
+        # ---- baseline N(0, I) -------------------------------------------------
+        if mode == "gaussian":
+            source = self._gaussian_baseline(shape, device, dtype, training, seed)
+            return self._finalize(source, shape, x0_B_HA_A, metrics, mode, randn)
+
+        # ---- debug: noisy ground-truth actions -------------------------------
+        if mode == "gt_action_noisy_debug":
+            if x0_B_HA_A is None or not training:
+                log.warning(
+                    "gt_action_noisy_debug requested without x0 / outside training; "
+                    "falling back to gaussian source."
+                )
+                source = self._gaussian_baseline(shape, device, dtype, training, seed)
+                return self._finalize(source, shape, x0_B_HA_A, metrics, "gaussian", randn)
+            source = x0_B_HA_A.float() + self.cfg.debug_noise_std * randn(shape)
+            return self._finalize(source, shape, x0_B_HA_A, metrics, mode, randn)
+
+        # ---- video-latent prior modes ----------------------------------------
+        assert self.net is not None, "video prior modes require an instantiated prior network"
+        if crossattn_emb is None:
+            raise ValueError(f"source_mode={mode!r} requires video crossattn_emb")
+
+        cond = crossattn_emb
+        shuffle_enabled = 0.0
+        if mode == "shuffled_video_prior":
+            perm = torch.randperm(B, device=device, generator=gen)
+            cond = cond[perm]
+            shuffle_enabled = 1.0
+
+        if self.cfg.detach_video_latents:
+            cond = cond.detach()
+
+        mu, logstd = self.net(cond, state_B_HO_O, context_timesteps_B_1, HA, language_B_L_D)
+        mu = mu.float()
+        logstd = logstd.float()
+        std = logstd.exp()
+        temperature = float(self.cfg.sampling_temperature)
+
+        # reparameterized "video" sample: s = mu + T * sigma * eps
+        eps = randn(shape)
+        source_video = mu + temperature * std * eps
+
+        dropout_rate_actual = torch.zeros((), device=device)
+        if mode == "video_prior_sample":
+            source = source_video
+        elif mode == "video_prior_mean":
+            source = mu  # deterministic
+        elif mode == "video_prior_residual":
+            # source = gaussian noise + residual * mu  (mu is a learned offset)
+            source = eps + float(self.cfg.residual_scale) * mu
+        elif mode == "video_prior_blend":
+            alpha = float(self.cfg.blend_alpha)
+            eps_g = randn(shape)
+            source = alpha * source_video + math.sqrt(max(1.0 - alpha * alpha, 0.0)) * eps_g
+        elif mode == "video_prior_dropout":
+            eps_g = randn(shape)
+            keep = self._make_dropout_mask(shape, 1.0 - float(self.cfg.source_dropout_prob), rand)
+            source = keep * source_video + (1.0 - keep) * eps_g
+            dropout_rate_actual = (1.0 - keep).mean()
+        elif mode == "shuffled_video_prior":
+            source = source_video
+        else:  # pragma: no cover - guarded by ALL_SOURCE_MODES
+            raise ValueError(f"unknown source_mode: {mode!r}")
+
+        # Keep BOTH heads in the autograd graph for *every* mode so DDP (with the
+        # default find_unused_parameters=False) never sees an unused parameter,
+        # even when a mode is deterministic (mean / residual) or all samples drop
+        # out.  The added term is numerically zero.
+        source = source + 0.0 * (mu.mean() + logstd.mean())
+
+        # tensors needed for regularization
+        metrics["mu"] = mu
+        metrics["logstd"] = logstd
+        metrics["source/shuffle_enabled"] = torch.as_tensor(shuffle_enabled, device=device)
+        metrics["source/dropout_rate_actual"] = dropout_rate_actual.detach()
+        with torch.no_grad():
+            metrics["source/mu_mean"] = mu.mean()
+            metrics["source/mu_std"] = mu.std()
+            metrics["source/logstd_mean"] = logstd.mean()
+            metrics["source/std_mean"] = std.mean()
+        return self._finalize(source, shape, x0_B_HA_A, metrics, mode, randn)
+
+    # ------------------------------------------------------------------ #
+    def _finalize(
+        self,
+        source: torch.Tensor,
+        shape: tuple[int, int, int],
+        x0_B_HA_A: torch.Tensor | None,
+        metrics: dict[str, torch.Tensor],
+        mode: str,
+        randn,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        source = source.reshape(shape).float()
+
+        # When VLSP is disabled the source is the plain Gaussian baseline.  We
+        # deliberately avoid *any* extra work (no GPU sync, no extra RNG draw) so
+        # the training/inference RNG stream stays bit-identical to the original.
+        if not self.cfg.enabled:
+            return source, metrics
+
+        if not torch.isfinite(source).all():
+            raise FloatingPointError(f"non-finite source produced by mode={mode!r}")
+        with torch.no_grad():
+            device = source.device
+            metrics.setdefault("source/mu_mean", torch.zeros((), device=device))
+            metrics.setdefault("source/mu_std", torch.zeros((), device=device))
+            metrics.setdefault("source/logstd_mean", torch.zeros((), device=device))
+            metrics.setdefault("source/std_mean", torch.ones((), device=device))
+            metrics.setdefault("source/shuffle_enabled", torch.zeros((), device=device))
+            metrics.setdefault("source/dropout_rate_actual", torch.zeros((), device=device))
+            metrics["source/source_mean"] = source.mean()
+            metrics["source/source_std"] = source.std()
+            metrics["source/source_mode_id"] = torch.as_tensor(
+                float(SOURCE_MODE_IDS.get(mode, -1)), device=device
+            )
+            if x0_B_HA_A is not None:
+                metrics["source/source_vs_x0_mse"] = F.mse_loss(source, x0_B_HA_A.float())
+            metrics["source/source_vs_gaussian_mse"] = F.mse_loss(source, randn(shape))
+        return source, metrics
+
+
+# --------------------------------------------------------------------------- #
+#  Action conditioning (independent of the source prior input)                 #
+# --------------------------------------------------------------------------- #
+def apply_action_conditioning(
+    crossattn_emb: torch.Tensor,
+    *,
+    mode: str,
+    dropout_prob: float = 0.0,
+    seed: int | None = None,
+    generator: torch.Generator | None = None,
+    training: bool = False,
+) -> torch.Tensor:
+    """Transform the video latent before it is fed to the action DiT cross-attn.
+
+    This is *separate* from the source-prior input so e.g. the source can use the
+    real video latent while the decoder receives a zeroed/shuffled condition.
+
+      * ``normal``        : pass-through (baseline)
+      * ``zero_video``    : replace with zeros (source-only experiments)
+      * ``shuffled_video``: shuffle across the batch (negative control)
+      * ``dropout_video`` : per-sample random zeroing with prob ``dropout_prob``
+    """
+    if mode == "normal":
+        return crossattn_emb
+
+    B = crossattn_emb.shape[0]
+    device = crossattn_emb.device
+    gen = generator
+    if gen is None and seed is not None and not training:
+        gen = torch.Generator(device=device)
+        gen.manual_seed(int(seed) + 1234)
+
+    if mode == "zero_video":
+        return torch.zeros_like(crossattn_emb)
+    if mode == "shuffled_video":
+        perm = torch.randperm(B, device=device, generator=gen)
+        return crossattn_emb[perm]
+    if mode == "dropout_video":
+        drop_B = torch.rand(B, device=device, generator=gen) < float(dropout_prob)
+        out = crossattn_emb.clone()
+        out[drop_B] = 0.0
+        return out
+    raise ValueError(f"unknown action_conditioning.mode: {mode!r}")
+
+
+# --------------------------------------------------------------------------- #
+#  Regularization                                                              #
+# --------------------------------------------------------------------------- #
+def compute_prior_regularization(
+    metrics: dict[str, torch.Tensor],
+    cfg: ActionSourcePriorConfig,
+) -> tuple[torch.Tensor | float, dict[str, torch.Tensor]]:
+    """Optional regularizers on the diagonal-Gaussian prior.
+
+    Returns ``(loss, log_dict)``.  ``loss`` is ``0.0`` (a python float, a no-op in
+    ``loss_flow + loss_prior``) when the prior is not a learned diagonal Gaussian
+    or all weights are zero.
+    """
+    mu = metrics.get("mu")
+    logstd = metrics.get("logstd")
+    logs: dict[str, torch.Tensor] = {}
+    if mu is None or logstd is None:
+        return 0.0, logs
+
+    total: torch.Tensor | float = 0.0
+
+    if cfg.kl_weight != 0.0:
+        # KL(N(mu, sigma^2) || N(0, I)) = 0.5 * (mu^2 + sigma^2 - 1 - 2*logstd)
+        var = (2.0 * logstd).exp()
+        kl = 0.5 * (mu.pow(2) + var - 1.0 - 2.0 * logstd).mean()
+        total = total + cfg.kl_weight * kl
+        logs["loss/source_kl"] = kl.detach()
+
+    if cfg.mean_l2_weight != 0.0:
+        mean_l2 = mu.pow(2).mean()
+        total = total + cfg.mean_l2_weight * mean_l2
+        logs["loss/source_mean_l2"] = mean_l2.detach()
+
+    if cfg.std_reg_weight != 0.0:
+        # Penalize collapse toward sigma << 1 (logstd < 0).
+        std_reg = F.relu(-logstd).mean()
+        total = total + cfg.std_reg_weight * std_reg
+        logs["loss/source_std_reg"] = std_reg.detach()
+
+    return total, logs

--- a/model/cosmos_predict2/models/action_source_prior.py
+++ b/model/cosmos_predict2/models/action_source_prior.py
@@ -518,7 +518,17 @@ class ActionSourcePrior(nn.Module):
         with torch.no_grad():
             metrics["source/mu_mean"] = mu.mean()
             metrics["source/mu_std"] = mu.std()
+            # Run-1 lesson: mu.std() is a GLOBAL std over [B, HA, A] and cannot
+            # distinguish "mu varies with the video" from "one fixed trajectory
+            # for every video".  mu_batch_std is the std ACROSS THE BATCH per
+            # (step, dim), averaged — ~0 means the prior ignores its input.
+            metrics["source/mu_batch_std"] = mu.float().std(dim=0, unbiased=False).mean()
             metrics["source/logstd_mean"] = logstd.mean()
+            # Fraction of logstd pinned at the clamp floor — variance-collapse
+            # alarm (run 1 sat at 1.0 with logstd_min=-5 for the entire run).
+            metrics["source/logstd_floor_frac"] = (
+                (logstd <= float(self.cfg.logstd_min) + 0.05).float().mean()
+            )
             metrics["source/std_mean"] = std.mean()
         return self._finalize(source, shape, x0_B_HA_A, metrics, mode, randn)
 
@@ -546,7 +556,9 @@ class ActionSourcePrior(nn.Module):
             device = source.device
             metrics.setdefault("source/mu_mean", torch.zeros((), device=device))
             metrics.setdefault("source/mu_std", torch.zeros((), device=device))
+            metrics.setdefault("source/mu_batch_std", torch.zeros((), device=device))
             metrics.setdefault("source/logstd_mean", torch.zeros((), device=device))
+            metrics.setdefault("source/logstd_floor_frac", torch.zeros((), device=device))
             metrics.setdefault("source/std_mean", torch.ones((), device=device))
             metrics.setdefault("source/shuffle_enabled", torch.zeros((), device=device))
             metrics.setdefault("source/dropout_rate_actual", torch.zeros((), device=device))

--- a/model/cosmos_predict2/models/action_source_prior.py
+++ b/model/cosmos_predict2/models/action_source_prior.py
@@ -518,18 +518,28 @@ class ActionSourcePrior(nn.Module):
         with torch.no_grad():
             metrics["source/mu_mean"] = mu.mean()
             metrics["source/mu_std"] = mu.std()
+            metrics["source/mu_abs_mean"] = mu.abs().mean()
+            metrics["source/mu_rms"] = mu.float().pow(2).mean().sqrt()
             # Run-1 lesson: mu.std() is a GLOBAL std over [B, HA, A] and cannot
             # distinguish "mu varies with the video" from "one fixed trajectory
             # for every video".  mu_batch_std is the std ACROSS THE BATCH per
             # (step, dim), averaged — ~0 means the prior ignores its input.
             metrics["source/mu_batch_std"] = mu.float().std(dim=0, unbiased=False).mean()
+            metrics["source/mu_horizon_std"] = mu.float().std(dim=1, unbiased=False).mean()
             metrics["source/logstd_mean"] = logstd.mean()
+            metrics["source/logstd_min"] = logstd.min()
+            metrics["source/logstd_max"] = logstd.max()
             # Fraction of logstd pinned at the clamp floor — variance-collapse
             # alarm (run 1 sat at 1.0 with logstd_min=-5 for the entire run).
             metrics["source/logstd_floor_frac"] = (
                 (logstd <= float(self.cfg.logstd_min) + 0.05).float().mean()
             )
+            metrics["source/logstd_ceiling_frac"] = (
+                (logstd >= float(self.cfg.logstd_max) - 0.05).float().mean()
+            )
             metrics["source/std_mean"] = std.mean()
+            metrics["source/std_min"] = std.min()
+            metrics["source/std_max"] = std.max()
         return self._finalize(source, shape, x0_B_HA_A, metrics, mode, randn)
 
     # ------------------------------------------------------------------ #
@@ -556,19 +566,34 @@ class ActionSourcePrior(nn.Module):
             device = source.device
             metrics.setdefault("source/mu_mean", torch.zeros((), device=device))
             metrics.setdefault("source/mu_std", torch.zeros((), device=device))
+            metrics.setdefault("source/mu_abs_mean", torch.zeros((), device=device))
+            metrics.setdefault("source/mu_rms", torch.zeros((), device=device))
             metrics.setdefault("source/mu_batch_std", torch.zeros((), device=device))
+            metrics.setdefault("source/mu_horizon_std", torch.zeros((), device=device))
             metrics.setdefault("source/logstd_mean", torch.zeros((), device=device))
+            metrics.setdefault("source/logstd_min", torch.zeros((), device=device))
+            metrics.setdefault("source/logstd_max", torch.zeros((), device=device))
             metrics.setdefault("source/logstd_floor_frac", torch.zeros((), device=device))
+            metrics.setdefault("source/logstd_ceiling_frac", torch.zeros((), device=device))
             metrics.setdefault("source/std_mean", torch.ones((), device=device))
+            metrics.setdefault("source/std_min", torch.ones((), device=device))
+            metrics.setdefault("source/std_max", torch.ones((), device=device))
             metrics.setdefault("source/shuffle_enabled", torch.zeros((), device=device))
             metrics.setdefault("source/dropout_rate_actual", torch.zeros((), device=device))
             metrics["source/source_mean"] = source.mean()
             metrics["source/source_std"] = source.std()
+            metrics["source/source_abs_mean"] = source.abs().mean()
+            metrics["source/source_rms"] = source.float().pow(2).mean().sqrt()
             metrics["source/source_mode_id"] = torch.as_tensor(
                 float(SOURCE_MODE_IDS.get(mode, -1)), device=device
             )
+            mu = metrics.get("mu")
+            if torch.is_tensor(mu):
+                metrics["source/source_vs_mu_mse"] = F.mse_loss(source, mu.float())
             if x0_B_HA_A is not None:
                 metrics["source/source_vs_x0_mse"] = F.mse_loss(source, x0_B_HA_A.float())
+                if torch.is_tensor(mu):
+                    metrics["source/mu_vs_x0_mse"] = F.mse_loss(mu.float(), x0_B_HA_A.float())
             metrics["source/source_vs_gaussian_mse"] = F.mse_loss(source, randn(shape))
         return source, metrics
 

--- a/model/cosmos_predict2/models/world2action_dit.py
+++ b/model/cosmos_predict2/models/world2action_dit.py
@@ -790,6 +790,7 @@ class World2ActionDIT(nn.Module):
         self.num_heads = num_heads
         self.num_blocks = num_blocks
         self.model_channels = model_channels
+        self.crossattn_emb_channels = crossattn_emb_channels
         self.atten_backend = atten_backend
         self.cuda_graphs = {}
 

--- a/model/cosmos_predict2/models/world2action_model.py
+++ b/model/cosmos_predict2/models/world2action_model.py
@@ -488,6 +488,16 @@ class World2ActionModel(ImaginaireModel):
                     if key in ("mu", "logstd"):
                         continue  # tensors used for regularization only
                     scalars[key] = val
+                eps = torch.as_tensor(1e-8, device=x0_B_HA_A.device)
+                source_vs_x0 = source_metrics.get("source/source_vs_x0_mse")
+                source_vs_gaussian = source_metrics.get("source/source_vs_gaussian_mse")
+                mu_vs_x0 = source_metrics.get("source/mu_vs_x0_mse")
+                if torch.is_tensor(source_vs_x0):
+                    scalars["source/source_vs_x0_over_var"] = source_vs_x0 / (var_inst_x0 + eps)
+                if torch.is_tensor(mu_vs_x0):
+                    scalars["source/mu_vs_x0_over_var"] = mu_vs_x0 / (var_inst_x0 + eps)
+                if torch.is_tensor(source_vs_x0) and torch.is_tensor(source_vs_gaussian):
+                    scalars["source/source_vs_gaussian_ratio"] = source_vs_x0 / (source_vs_gaussian + eps)
                 cond_mode = self.pipe.config.action_conditioning.mode
                 scalars["condition/mode_id"] = torch.as_tensor(
                     float(COND_MODE_IDS.get(cond_mode, -1)), device=loss.device

--- a/model/cosmos_predict2/models/world2action_model.py
+++ b/model/cosmos_predict2/models/world2action_model.py
@@ -14,11 +14,16 @@
 # limitations under the License.
 import collections
 import gc
+import json
 import math
+import os
+import pathlib
+import time
 from collections.abc import Mapping
 from typing import Any
 
 import attrs
+import numpy as np
 import torch
 import torch.distributed as dist
 from einops import rearrange
@@ -70,6 +75,18 @@ class World2ActionModelConfig:
     fsdp_shard_size: int  # 0 means not using fsdp, -1 means set to world size
     data_config: DictConfig
 
+    # Optional cache produced by tools/precompute_libero_video_embeddings.py.
+    # When set, training reads frozen video2world hidden states from disk and does
+    # not instantiate or run the video2world backbone online.
+    offline_video_embedding_dir: str = ""
+    offline_video_embedding_required: bool = False
+
+    # Optional cache produced by tools/precompute_libero_video_latents.py.
+    # This stores tokenizer latents, so training still runs the frozen video2world
+    # DiT online but skips zarr RGB loading and tokenizer.encode.
+    offline_video_latent_dir: str = ""
+    offline_video_latent_required: bool = False
+
 
 def _dp_mean(x: torch.Tensor) -> torch.Tensor:
     if dist.is_available() and dist.is_initialized():
@@ -105,6 +122,14 @@ class World2ActionModel(ImaginaireModel):
         assert self.loss_reduce in ["mean", "sum"]
         self.loss_scale = getattr(config, "loss_scale", 1.0)
         log.critical(f"Using {self.loss_reduce} loss reduce with loss scale {self.loss_scale}")
+        self.debug_w2a_timing = os.environ.get("DEBUG_W2A_TIMING", "0").lower() in {"1", "true", "yes", "on"}
+        self.debug_w2a_timing_interval = max(1, int(os.environ.get("DEBUG_W2A_TIMING_INTERVAL", "10")))
+        self.debug_w2a_timing_all_ranks = os.environ.get("DEBUG_W2A_TIMING_ALL_RANKS", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
         self.pipe: World2ActionPipeline = World2ActionPipeline.from_config(
             config.pipe_config,
@@ -112,16 +137,37 @@ class World2ActionModel(ImaginaireModel):
             **self.tensor_kwargs,
         )
 
-        self.video2world_pipe: Video2WorldPipeline = Video2WorldPipeline.from_config(
-            config.video_pipe_config,
-            dit_path=config.video_dit_path,
-            use_text_encoder=False,
-        )
-        self.video2world_pipe.requires_grad_(False)
         if config.video_pipe_config.adjust_video_noise:
             self.video_noise_multiplier = math.sqrt(config.video_pipe_config.state_t)
         else:
             self.video_noise_multiplier = 1.0
+
+        self.video2world_pipe: Video2WorldPipeline | None = None
+        self._offline_video_embedding_dir: pathlib.Path | None = None
+        self._offline_crossattn_emb: np.memmap | None = None
+        self._offline_video_sigma: np.memmap | None = None
+        self._offline_video_embedding_meta: dict[str, Any] | None = None
+        self._offline_video_latent_dir: pathlib.Path | None = None
+        self._offline_video_latent: np.memmap | None = None
+        self._offline_video_latent_meta: dict[str, Any] | None = None
+        self._offline_video_latent_num_conditional_frames: int | None = None
+        if config.offline_video_embedding_dir and config.offline_video_latent_dir:
+            raise ValueError("offline_video_embedding_dir and offline_video_latent_dir are mutually exclusive")
+        if config.offline_video_embedding_dir:
+            self._load_offline_video_embeddings(pathlib.Path(config.offline_video_embedding_dir))
+        elif config.offline_video_embedding_required:
+            raise ValueError("offline_video_embedding_required=True but offline_video_embedding_dir is empty")
+        else:
+            self.video2world_pipe = Video2WorldPipeline.from_config(
+                config.video_pipe_config,
+                dit_path=config.video_dit_path,
+                use_text_encoder=False,
+            )
+            self.video2world_pipe.requires_grad_(False)
+            if config.offline_video_latent_dir:
+                self._load_offline_video_latents(pathlib.Path(config.offline_video_latent_dir))
+            elif config.offline_video_latent_required:
+                raise ValueError("offline_video_latent_required=True but offline_video_latent_dir is empty")
 
         self.freeze_parameters()
         if config.train_architecture == "lora":
@@ -178,6 +224,22 @@ class World2ActionModel(ImaginaireModel):
             self.pipe.apply_fsdp(dp_mesh)
         else:
             log.info("FSDP (Fully Sharded Data Parallel) is disabled.")
+
+    def _debug_w2a_timing_rank(self) -> int:
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank()
+        return 0
+
+    def _debug_w2a_timing_should_log(self, iteration: int) -> bool:
+        if not self.debug_w2a_timing:
+            return False
+        if iteration % self.debug_w2a_timing_interval != 0:
+            return False
+        return self.debug_w2a_timing_all_ranks or self._debug_w2a_timing_rank() == 0
+
+    def _debug_w2a_cuda_sync(self) -> None:
+        if self.debug_w2a_timing and torch.cuda.is_available():
+            torch.cuda.synchronize()
 
     # New function, added for i4 adaption
     @property
@@ -399,34 +461,222 @@ class World2ActionModel(ImaginaireModel):
 
         return output_batch, loss
 
+    def _load_offline_video_embeddings(self, embedding_dir: pathlib.Path) -> None:
+        meta_path = embedding_dir / "metadata.json"
+        if not meta_path.exists():
+            raise FileNotFoundError(f"offline video embedding metadata is missing: {meta_path}")
+        with meta_path.open() as f:
+            meta = json.load(f)
+
+        if int(meta.get("xattn_layer_idx", -1)) != int(self.pipe.config.xattn_layer_idx):
+            raise ValueError(
+                "offline video embedding layer mismatch: "
+                f"cache has {meta.get('xattn_layer_idx')}, model expects {self.pipe.config.xattn_layer_idx}"
+            )
+        if meta.get("crossattn_dtype") != "float16":
+            raise ValueError(f"unsupported offline crossattn dtype: {meta.get('crossattn_dtype')!r}")
+
+        crossattn_path = embedding_dir / meta.get("crossattn_file", "crossattn_emb.fp16.memmap")
+        sigma_path = embedding_dir / meta.get("video_sigma_file", "video_sigma.npy")
+        if not crossattn_path.exists():
+            raise FileNotFoundError(f"offline cross-attention embedding file is missing: {crossattn_path}")
+        if not sigma_path.exists():
+            raise FileNotFoundError(f"offline video sigma file is missing: {sigma_path}")
+
+        crossattn_shape = tuple(int(v) for v in meta["crossattn_shape"])
+        self._offline_crossattn_emb = np.memmap(crossattn_path, dtype=np.float16, mode="r", shape=crossattn_shape)
+        self._offline_video_sigma = np.load(sigma_path, mmap_mode="r")
+        if tuple(self._offline_video_sigma.shape) != (crossattn_shape[0], 1):
+            raise ValueError(
+                f"offline video_sigma shape {self._offline_video_sigma.shape} does not match "
+                f"expected {(crossattn_shape[0], 1)}"
+            )
+
+        self._offline_video_embedding_dir = embedding_dir
+        self._offline_video_embedding_meta = meta
+        log.info(
+            "Using offline video embeddings from "
+            f"{embedding_dir} with shape={crossattn_shape}, dtype=float16"
+        )
+
+    def _get_offline_crossattn_emb(self, data_batch: dict) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._offline_crossattn_emb is None or self._offline_video_sigma is None:
+            raise RuntimeError("offline video embedding cache is not loaded")
+        if "sample_idx" not in data_batch:
+            raise KeyError(
+                "offline video embeddings require data_batch['sample_idx']; "
+                "regenerate the dataloader after the MimicDataset sample_idx patch"
+            )
+
+        sample_idx = data_batch["sample_idx"]
+        if torch.is_tensor(sample_idx):
+            sample_idx_np = sample_idx.detach().cpu().numpy().astype(np.int64, copy=False).reshape(-1)
+        else:
+            sample_idx_np = np.asarray(sample_idx, dtype=np.int64).reshape(-1)
+
+        max_idx = int(sample_idx_np.max(initial=-1))
+        min_idx = int(sample_idx_np.min(initial=0))
+        if min_idx < 0 or max_idx >= self._offline_crossattn_emb.shape[0]:
+            raise IndexError(
+                f"sample_idx range [{min_idx}, {max_idx}] is outside offline cache length "
+                f"{self._offline_crossattn_emb.shape[0]}"
+            )
+
+        crossattn_np = np.asarray(self._offline_crossattn_emb[sample_idx_np], dtype=np.float16)
+        sigma_np = np.asarray(self._offline_video_sigma[sample_idx_np], dtype=np.float32)
+        crossattn_emb = torch.from_numpy(crossattn_np).to(**self.tensor_kwargs)
+        video_sigma_B_1 = torch.from_numpy(sigma_np).to(device=self.tensor_kwargs["device"], dtype=torch.float32)
+        return crossattn_emb, video_sigma_B_1
+
+    def _load_offline_video_latents(self, latent_dir: pathlib.Path) -> None:
+        if self.video2world_pipe is None:
+            raise RuntimeError("offline video latents require the online video2world pipe")
+        meta_path = latent_dir / "metadata.json"
+        if not meta_path.exists():
+            raise FileNotFoundError(f"offline video latent metadata is missing: {meta_path}")
+        with meta_path.open() as f:
+            meta = json.load(f)
+
+        if meta.get("latent_dtype") != "float16":
+            raise ValueError(f"unsupported offline video latent dtype: {meta.get('latent_dtype')!r}")
+        latent_shape = tuple(int(v) for v in meta["latent_shape"])
+        expected_tail = (self.video2world_pipe.config.state_ch, self.video2world_pipe.config.state_t, 60, 80)
+        if tuple(latent_shape[1:]) != expected_tail:
+            raise ValueError(
+                f"offline video latent shape {latent_shape} does not match expected (*, {expected_tail})"
+            )
+
+        latent_path = latent_dir / meta.get("latent_file", "video_latent.fp16.memmap")
+        if not latent_path.exists():
+            raise FileNotFoundError(f"offline video latent file is missing: {latent_path}")
+
+        self._offline_video_latent = np.memmap(latent_path, dtype=np.float16, mode="r", shape=latent_shape)
+        self._offline_video_latent_dir = latent_dir
+        self._offline_video_latent_meta = meta
+        self._offline_video_latent_num_conditional_frames = int(meta.get("num_latent_conditional_frames", 2))
+        log.info(
+            "Using offline video tokenizer latents from "
+            f"{latent_dir} with shape={latent_shape}, dtype=float16, "
+            f"num_conditional_frames={self._offline_video_latent_num_conditional_frames}"
+        )
+
+    def _get_sample_idx_np(self, data_batch: dict, *, cache_name: str, cache_len: int) -> np.ndarray:
+        if "sample_idx" not in data_batch:
+            raise KeyError(
+                f"{cache_name} requires data_batch['sample_idx']; "
+                "regenerate the dataloader after the MimicDataset sample_idx patch"
+            )
+        sample_idx = data_batch["sample_idx"]
+        if torch.is_tensor(sample_idx):
+            sample_idx_np = sample_idx.detach().cpu().numpy().astype(np.int64, copy=False).reshape(-1)
+        else:
+            sample_idx_np = np.asarray(sample_idx, dtype=np.int64).reshape(-1)
+
+        max_idx = int(sample_idx_np.max(initial=-1))
+        min_idx = int(sample_idx_np.min(initial=0))
+        if min_idx < 0 or max_idx >= cache_len:
+            raise IndexError(f"sample_idx range [{min_idx}, {max_idx}] is outside {cache_name} length {cache_len}")
+        return sample_idx_np
+
+    def _get_offline_video_latent_and_condition(self, data_batch: dict) -> tuple[torch.Tensor, Any]:
+        if self.video2world_pipe is None or self._offline_video_latent is None:
+            raise RuntimeError("offline video latent cache is not loaded")
+        sample_idx_np = self._get_sample_idx_np(
+            data_batch,
+            cache_name="offline video latent cache",
+            cache_len=self._offline_video_latent.shape[0],
+        )
+        latent_np = np.asarray(self._offline_video_latent[sample_idx_np], dtype=np.float16)
+        latent_state = torch.from_numpy(latent_np).to(device=self.tensor_kwargs["device"], dtype=torch.float32)
+
+        B, _C, _T, H, W = latent_state.shape
+        data_batch["padding_mask"] = torch.zeros(B, 1, H, W, **self.video2world_pipe.tensor_kwargs)
+        data_batch["fps"] = torch.full((B, 1), 5, **self.video2world_pipe.tensor_kwargs)
+
+        condition = self.video2world_pipe.conditioner(data_batch)
+        condition = condition.edit_data_type(DataType.VIDEO)
+        condition = condition.set_video_condition(
+            gt_frames=latent_state.to(**self.video2world_pipe.tensor_kwargs),
+            random_min_num_conditional_frames=self.video2world_pipe.config.min_num_conditional_frames,
+            random_max_num_conditional_frames=self.video2world_pipe.config.max_num_conditional_frames,
+            num_conditional_frames=self._offline_video_latent_num_conditional_frames,
+        )
+        return latent_state, condition
+
     def get_crossattn_emb(
         self,
         data_batch: dict,
         video_sigma_B_1: torch.Tensor | None = None,
+        debug_times: dict[str, float] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        _, video_B_C_T_H_W, condition = self.video2world_pipe.get_mimic_data_and_condition(data_batch)
+        if self._offline_crossattn_emb is not None:
+            if video_sigma_B_1 is not None:
+                raise ValueError("offline video embeddings store a fixed video sigma; explicit video_sigma_B_1 is unsupported")
+            if debug_times is None:
+                return self._get_offline_crossattn_emb(data_batch)
+            self._debug_w2a_cuda_sync()
+            offline_t0 = time.perf_counter()
+            result = self._get_offline_crossattn_emb(data_batch)
+            self._debug_w2a_cuda_sync()
+            debug_times["crossattn/offline_lookup"] = time.perf_counter() - offline_t0
+            return result
 
-        video_epsilon_B_C_T_H_W = torch.randn(video_B_C_T_H_W.size(), **self.tensor_kwargs)
+        if self.video2world_pipe is None:
+            raise RuntimeError("video2world pipe is not loaded and no offline video embedding cache is available")
 
-        if video_sigma_B_1 is None:
-            video_sigma_B_1 = self.draw_video_sigma(video_B_C_T_H_W.size(), condition)
+        with torch.no_grad():
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                mimic_t0 = time.perf_counter()
+            if self._offline_video_latent is not None:
+                video_B_C_T_H_W, condition = self._get_offline_video_latent_and_condition(data_batch)
+                timing_key = "crossattn/latent_lookup_condition"
+            else:
+                _, video_B_C_T_H_W, condition = self.video2world_pipe.get_mimic_data_and_condition(data_batch)
+                timing_key = "crossattn/mimic_tokenizer_condition"
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                debug_times[timing_key] = time.perf_counter() - mimic_t0
 
-        world_pred = self.video2world_pipe.denoise(
-            video_B_C_T_H_W + video_epsilon_B_C_T_H_W * rearrange(video_sigma_B_1, "b t -> b 1 t 1 1"),
-            video_sigma_B_1,
-            condition,
-            use_cuda_graphs=False,
-            return_only_hidden_states_up_to=self.pipe.config.xattn_layer_idx,
-            return_decoded_video=False,
-        )
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                sigma_t0 = time.perf_counter()
+            video_epsilon_B_C_T_H_W = torch.randn(video_B_C_T_H_W.size(), **self.tensor_kwargs)
 
-        crossattn_emb = world_pred.hidden_states[self.pipe.config.xattn_layer_idx]
+            if video_sigma_B_1 is None:
+                video_sigma_B_1 = self.draw_video_sigma(video_B_C_T_H_W.size(), condition)
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                debug_times["crossattn/noise_sigma"] = time.perf_counter() - sigma_t0
 
-        del world_pred
-        gc.collect(0)
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                denoise_t0 = time.perf_counter()
+            world_pred = self.video2world_pipe.denoise(
+                video_B_C_T_H_W + video_epsilon_B_C_T_H_W * rearrange(video_sigma_B_1, "b t -> b 1 t 1 1"),
+                video_sigma_B_1,
+                condition,
+                use_cuda_graphs=False,
+                return_only_hidden_states_up_to=self.pipe.config.xattn_layer_idx,
+                return_decoded_video=False,
+            )
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                debug_times["crossattn/video_dit_to_layer"] = time.perf_counter() - denoise_t0
 
-        B, T, H, W, D = crossattn_emb.shape
-        crossattn_emb = crossattn_emb.reshape(B, T * H * W, D)
+            crossattn_emb = world_pred.hidden_states[self.pipe.config.xattn_layer_idx]
+
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                reshape_t0 = time.perf_counter()
+            del world_pred
+            gc.collect(0)
+
+            B, T, H, W, D = crossattn_emb.shape
+            crossattn_emb = crossattn_emb.reshape(B, T * H * W, D)
+            if debug_times is not None:
+                self._debug_w2a_cuda_sync()
+                debug_times["crossattn/reshape_gc"] = time.perf_counter() - reshape_t0
 
         return crossattn_emb, video_sigma_B_1
 
@@ -437,6 +687,8 @@ class World2ActionModel(ImaginaireModel):
         return self.pipe(state_B_HO_O, crossattn_emb, video_sigma_B_1)
 
     def draw_video_sigma(self, x0_size: torch.Size, condition: Any) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.video2world_pipe is None:
+            raise RuntimeError("draw_video_sigma requires the online video2world pipe")
         batch_size = x0_size[0]
 
         sigma_B = self.video2world_pipe.scheduler.sample_sigma(batch_size)
@@ -458,14 +710,31 @@ class World2ActionModel(ImaginaireModel):
         return sigma_B_1
 
     def training_step(self, data_batch: dict, iteration: int) -> tuple[dict, torch.Tensor]:
+        debug_times: dict[str, float] | None = {} if self._debug_w2a_timing_should_log(iteration) else None
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            total_t0 = time.perf_counter()
+
         data_batch["obs/language_embedding"] = data_batch["obs/language_embedding"].squeeze(1)
         B, _HA, A = data_batch["action/lowdim_concat"].shape
         if "obs/lowdim_concat" not in data_batch:
             data_batch["obs/lowdim_concat"] = torch.empty((B, 0, A), **self.tensor_kwargs)
 
-        crossattn_emb, video_sigma_B_1 = self.get_crossattn_emb(data_batch)
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            crossattn_t0 = time.perf_counter()
+        crossattn_emb, video_sigma_B_1 = self.get_crossattn_emb(data_batch, debug_times=debug_times)
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["crossattn/total"] = time.perf_counter() - crossattn_t0
 
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            norm_t0 = time.perf_counter()
         normalised_data_batch: dict = self.pipe.normalizer(data_batch, strict=False)
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["normalizer"] = time.perf_counter() - norm_t0
 
         x0_B_HA_A = normalised_data_batch["action/lowdim_concat"]
 
@@ -479,6 +748,9 @@ class World2ActionModel(ImaginaireModel):
 
         # VLSP: draw the flow source first (gaussian == the old epsilon draw),
         # then the timestep -> identical RNG order to the original baseline.
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            source_prior_t0 = time.perf_counter()
         source_B_HA_A, source_metrics = self.pipe.sample_action_source(
             x0_shape=x0_B_HA_A.size(),
             crossattn_emb=crossattn_emb,
@@ -488,12 +760,31 @@ class World2ActionModel(ImaginaireModel):
             language_B_L_D=language_B_L_D,
             training=True,
         )
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["source_prior"] = time.perf_counter() - source_prior_t0
+
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            train_t_t0 = time.perf_counter()
         t_B_HA_1 = self.draw_training_t(x0_B_HA_A.size())
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["action_t_sample"] = time.perf_counter() - train_t_t0
 
         # VLSP: optionally zero / shuffle / drop the video condition fed to the
         # action DiT (independent of the source prior input above).
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            action_cond_t0 = time.perf_counter()
         crossattn_for_action = self.pipe.prepare_action_condition(crossattn_emb, training=True)
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["action_condition"] = time.perf_counter() - action_cond_t0
 
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            action_loss_t0 = time.perf_counter()
         output_batch, loss = self.compute_loss(
             x0_B_HA_A,
             source_B_HA_A,
@@ -503,6 +794,25 @@ class World2ActionModel(ImaginaireModel):
             state_B_HO_O,
             source_metrics,
         )
+        if debug_times is not None:
+            self._debug_w2a_cuda_sync()
+            debug_times["action_loss_forward"] = time.perf_counter() - action_loss_t0
+            debug_times["total_forward_body"] = time.perf_counter() - total_t0
+            print(
+                "[W2A_TIMING]"
+                f"[rank={self._debug_w2a_timing_rank()}]"
+                f"[step={iteration}] "
+                f"crossattn={debug_times.get('crossattn/total', 0.0):.3f}s "
+                f"mimic_tokenizer={debug_times.get('crossattn/mimic_tokenizer_condition', 0.0):.3f}s "
+                f"latent_lookup={debug_times.get('crossattn/latent_lookup_condition', 0.0):.3f}s "
+                f"video_dit={debug_times.get('crossattn/video_dit_to_layer', 0.0):.3f}s "
+                f"offline_lookup={debug_times.get('crossattn/offline_lookup', 0.0):.3f}s "
+                f"source_prior={debug_times.get('source_prior', 0.0):.3f}s "
+                f"action_loss_fwd={debug_times.get('action_loss_forward', 0.0):.3f}s "
+                f"total_body={debug_times.get('total_forward_body', 0.0):.3f}s "
+                f"local_bsz={B}",
+                flush=True,
+            )
 
         return output_batch, loss
 

--- a/model/cosmos_predict2/models/world2action_model.py
+++ b/model/cosmos_predict2/models/world2action_model.py
@@ -24,6 +24,7 @@ import torch.distributed as dist
 from einops import rearrange
 from megatron.core import parallel_state
 from omegaconf import DictConfig
+from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
 from torch.nn import functional as F
@@ -33,6 +34,7 @@ from cosmos_predict2.conditioner import DataType
 from cosmos_predict2.configs.config_video2world import EMAConfig
 from cosmos_predict2.configs.config_world2action import World2ActionPipelineConfig
 from cosmos_predict2.data.action.utils import extract_normalization_types
+from cosmos_predict2.models.action_source_prior import COND_MODE_IDS, compute_prior_regularization
 from cosmos_predict2.pipelines.video2world import (
     Video2WorldPipeline,
     Video2WorldPipelineConfig,
@@ -140,6 +142,18 @@ class World2ActionModel(ImaginaireModel):
                 )
         else:
             self.pipe.denoising_model().requires_grad_(True)
+
+        # VLSP: the video-latent source prior is always fully trainable (even in
+        # LoRA mode); the video model stays frozen.  Match the trainable dtype of
+        # the action DiT so the optimizer param group is homogeneous: LoRA upcasts
+        # its trainable params to fp32, base training keeps them in self.precision.
+        if self.pipe.source_prior_has_params:
+            self.pipe.source_prior.requires_grad_(True)
+            self.pipe.source_prior.train()
+            if config.train_architecture == "lora":
+                for p in self.pipe.source_prior.parameters():
+                    p.data = p.data.to(torch.float32)
+
         total_params = sum(p.numel() for p in self.parameters())
         frozen_params = sum(p.numel() for p in self.parameters() if not p.requires_grad)
         trainable_params = sum(p.numel() for p in self.parameters() if p.requires_grad)
@@ -191,7 +205,13 @@ class World2ActionModel(ImaginaireModel):
             optimizer (torch.optim.Optimizer): The model optimizer.
             scheduler (torch.optim.lr_scheduler.LRScheduler): The optimization scheduler.
         """
-        optimizer: torch.optim.Optimizer = instantiate(optimizer_config, model=self.net)
+        # Include the VLSP source prior's parameters in the optimizer. The DiT
+        # keeps its base/LoRA trainability; the source prior is fully trainable.
+        if self.pipe.source_prior_has_params:
+            optim_module: nn.Module = nn.ModuleList([self.net, self.pipe.source_prior])
+        else:
+            optim_module = self.net
+        optimizer: torch.optim.Optimizer = instantiate(optimizer_config, model=optim_module)
         scheduler = get_base_scheduler(optimizer, self, scheduler_config)
         return optimizer, scheduler
 
@@ -211,6 +231,24 @@ class World2ActionModel(ImaginaireModel):
             # calculate beta for EMA update
             ema_beta = self.ema_beta(iteration)
             self.pipe.dit_ema_worker.update_average(self.net, self.net_ema, beta=ema_beta)
+            if self.pipe.source_prior_ema is not None:
+                self._update_source_prior_ema(ema_beta)
+
+    @torch.no_grad()
+    def _update_source_prior_ema(self, beta: float) -> None:
+        """Param-wise EMA for the VLSP source prior (weights = beta*ema + (1-beta)*new).
+
+        Implemented for the standard DDP / non-FSDP path. FSDP+EMA for the source
+        prior is not specially handled (the prior is small and left replicated);
+        see VLSP.md for the limitation.
+        """
+        src_params = dict(self.pipe.source_prior.named_parameters())
+        for name, p_ema in self.pipe.source_prior_ema.named_parameters():
+            p_ema.mul_(beta).add_(src_params[name].detach(), alpha=1.0 - beta)
+        src_buffers = dict(self.pipe.source_prior.named_buffers())
+        for name, b_ema in self.pipe.source_prior_ema.named_buffers():
+            if name in src_buffers:
+                b_ema.copy_(src_buffers[name])
 
     # New function, added for i4 adaption
     def on_train_start(self, memory_format: torch.memory_format, dataset_stats: dict, stats_id: str) -> None:
@@ -267,33 +305,42 @@ class World2ActionModel(ImaginaireModel):
 
         return t_B.unsqueeze(1).repeat(1, x0_size[1]).unsqueeze(2), epsilon
 
-    def compute_loss_with_epsilon_and_t(
+    def draw_training_t(self, x0_size: torch.Size) -> torch.Tensor:
+        """Draw the flow-matching timestep only.
+
+        The source endpoint is drawn separately via ``pipe.sample_action_source``;
+        with ``source_mode="gaussian"`` that draw matches the old epsilon exactly,
+        and drawing it *before* the timestep preserves the original RNG order.
+        """
+        t_B = self.pipe.scheduler.sample_t(x0_size[0])
+        return t_B.unsqueeze(1).repeat(1, x0_size[1]).unsqueeze(2)
+
+    def compute_loss(
         self,
         x0_B_HA_A: torch.Tensor,
-        epsilon_B_HA_A: torch.Tensor,
+        source_B_HA_A: torch.Tensor,
         t_B_HA_1: torch.Tensor,
         crossattn_emb: torch.Tensor,
         video_sigma_B_1: torch.Tensor,
         state_B_HO_O: torch.Tensor,
+        source_metrics: dict[str, torch.Tensor],
     ) -> tuple[dict, torch.Tensor]:
-        """
-        Compute loss given epsilon and t
+        """Flow-matching loss with a configurable source endpoint (VLSP).
 
-        It involves:
-        1. Adding noise to the input data.
-        2. Passing the noisy data through the network to generate predictions.
-        3. Computing the loss based on the difference between the predictions and the original data.
+        Interpolate between the (normalized) action ``x0`` and the source ``s``,
+        predict the flow field ``u_t = s - x0`` and regress it, optionally adding
+        a regularizer on the learned source prior:
 
-        Args:
-            data_batch (dict): raw data batch draw from the training data loader.
-            x0: image/video latent
-            crossattn_emb: video condition
-            epsilon: noise
-            t: noise level
+            x_t = (1 - t) * x0 + t * s
+            u_t = s - x0
+            L   = || v_theta(x_t, t, c) - u_t ||^2  +  L_prior
+
+        With ``source_mode="gaussian"`` (the default) ``s`` is N(0, I) and this is
+        identical to the original action flow loss.
         """
         # scale to have unit variance. don't know if this helps.
-        xt_B_HA_A = (1 - t_B_HA_1) * x0_B_HA_A + t_B_HA_1 * epsilon_B_HA_A
-        ut_B_HA_A = epsilon_B_HA_A - x0_B_HA_A
+        xt_B_HA_A = (1 - t_B_HA_1) * x0_B_HA_A + t_B_HA_1 * source_B_HA_A
+        ut_B_HA_A = source_B_HA_A - x0_B_HA_A
 
         vt_B_HA_A = self.pipe.denoise(
             xt_B_HA_A,
@@ -304,29 +351,50 @@ class World2ActionModel(ImaginaireModel):
             obs_dropout=0.2,
             return_hidden_states=False,
         ).float()
-        loss = F.mse_loss(vt_B_HA_A, ut_B_HA_A, reduction=self.loss_reduce) * self.loss_scale
+        loss_flow = F.mse_loss(vt_B_HA_A, ut_B_HA_A, reduction=self.loss_reduce) * self.loss_scale
+
+        # Optional regularizers on q_phi(s | video) (KL / mean-L2 / std). All
+        # weights default to 0.0, so loss_prior is a no-op for the baseline.
+        loss_prior, prior_logs = compute_prior_regularization(source_metrics, self.pipe.config.action_source_prior)
+        loss = loss_flow + loss_prior
 
         with torch.no_grad():
             var_inst_x0 = x0_B_HA_A.float().var(dim=(1, 2)).mean()
 
-            metrics = torch.stack(
-                [
-                    loss.float(),
-                    var_inst_x0,
-                ],
-                dim=0,
-            ).to(x0_B_HA_A.device)
-            metrics = _dp_mean(metrics)
-
-            if not dist.is_available() or not dist.is_initialized() or parallel_state.get_data_parallel_rank() == 0:
-                output_batch = {
-                    "loss": metrics[0].item(),
-                    "Var_inst[x_0]": metrics[1].item(),
-                }
+            if not self.pipe.source_prior_enabled:
+                # Exact baseline logging path (same keys / collective as before).
+                metrics = _dp_mean(torch.stack([loss.float(), var_inst_x0], dim=0).to(x0_B_HA_A.device))
+                if not dist.is_available() or not dist.is_initialized() or parallel_state.get_data_parallel_rank() == 0:
+                    output_batch = {"loss": metrics[0].item(), "Var_inst[x_0]": metrics[1].item()}
+                else:
+                    output_batch = {}
             else:
-                output_batch = {}
+                scalars: dict[str, torch.Tensor] = {
+                    "loss": loss.detach().float(),
+                    "loss/flow": loss_flow.detach().float(),
+                    "Var_inst[x_0]": var_inst_x0,
+                }
+                if torch.is_tensor(loss_prior):
+                    scalars["loss/source_prior"] = loss_prior.detach().float()
+                scalars.update(prior_logs)
+                for key, val in source_metrics.items():
+                    if key in ("mu", "logstd"):
+                        continue  # tensors used for regularization only
+                    scalars[key] = val
+                cond_mode = self.pipe.config.action_conditioning.mode
+                scalars["condition/mode_id"] = torch.as_tensor(
+                    float(COND_MODE_IDS.get(cond_mode, -1)), device=loss.device
+                )
+                scalars["condition/shuffle_enabled"] = torch.as_tensor(
+                    1.0 if cond_mode == "shuffled_video" else 0.0, device=loss.device
+                )
+                reduced = _dp_mean_dict(scalars, device=x0_B_HA_A.device)
+                if not dist.is_available() or not dist.is_initialized() or parallel_state.get_data_parallel_rank() == 0:
+                    output_batch = reduced
+                else:
+                    output_batch = {}
 
-        del var_inst_x0  # , var_batch_x0, var_eps, var_xt, var_ut, var_vt
+        del var_inst_x0
         gc.collect(0)
 
         return output_batch, loss
@@ -403,15 +471,37 @@ class World2ActionModel(ImaginaireModel):
 
         state_B_HO_O = normalised_data_batch["obs/lowdim_concat"]
 
-        t_B_HA_1, epsilon_B_HA_A = self.draw_training_t_and_epsilon(x0_B_HA_A.size())
+        language_B_L_D = (
+            data_batch.get("obs/language_embedding")
+            if self.pipe.config.action_source_prior.use_language
+            else None
+        )
 
-        output_batch, loss = self.compute_loss_with_epsilon_and_t(
+        # VLSP: draw the flow source first (gaussian == the old epsilon draw),
+        # then the timestep -> identical RNG order to the original baseline.
+        source_B_HA_A, source_metrics = self.pipe.sample_action_source(
+            x0_shape=x0_B_HA_A.size(),
+            crossattn_emb=crossattn_emb,
+            state_B_HO_O=state_B_HO_O,
+            context_timesteps_B_1=video_sigma_B_1,
+            x0_B_HA_A=x0_B_HA_A,
+            language_B_L_D=language_B_L_D,
+            training=True,
+        )
+        t_B_HA_1 = self.draw_training_t(x0_B_HA_A.size())
+
+        # VLSP: optionally zero / shuffle / drop the video condition fed to the
+        # action DiT (independent of the source prior input above).
+        crossattn_for_action = self.pipe.prepare_action_condition(crossattn_emb, training=True)
+
+        output_batch, loss = self.compute_loss(
             x0_B_HA_A,
-            epsilon_B_HA_A,
+            source_B_HA_A,
             t_B_HA_1,
-            crossattn_emb,
+            crossattn_for_action,
             video_sigma_B_1,
             state_B_HO_O,
+            source_metrics,
         )
 
         return output_batch, loss
@@ -505,6 +595,14 @@ class World2ActionModel(ImaginaireModel):
             ema_state_dict = self.pipe.dit_ema.state_dict(prefix="net_ema.")
             net_state_dict.update(ema_state_dict)
 
+        # VLSP: persist the source prior (and its EMA) alongside the DiT weights.
+        # Keys are prefixed so they round-trip through load_state_dict below and
+        # do not collide with the action/ema DiT keys.
+        if self.pipe.source_prior_has_params:
+            net_state_dict.update(self.pipe.source_prior.state_dict(prefix="source_prior."))
+            if self.config.pipe_config.ema.enabled and self.pipe.source_prior_ema is not None:
+                net_state_dict.update(self.pipe.source_prior_ema.state_dict(prefix="source_prior_ema."))
+
         # convert DTensor to Tensor
         for key, val in net_state_dict.items():
             if isinstance(val, DTensor):
@@ -531,11 +629,37 @@ class World2ActionModel(ImaginaireModel):
         """
         _reg_state_dict = collections.OrderedDict()
         _ema_state_dict = collections.OrderedDict()
+        _sp_state_dict = collections.OrderedDict()
+        _sp_ema_state_dict = collections.OrderedDict()
         for k, v in state_dict.items():
             if k.startswith("net."):
                 _reg_state_dict[k.replace("net.", "")] = v
             elif k.startswith("net_ema."):
                 _ema_state_dict[k.replace("net_ema.", "")] = v
+            elif k.startswith("source_prior_ema."):
+                _sp_ema_state_dict[k[len("source_prior_ema.") :]] = v
+            elif k.startswith("source_prior."):
+                _sp_state_dict[k[len("source_prior.") :]] = v
+
+        # VLSP: load the source prior non-strictly so that (a) old checkpoints with
+        # no source-prior keys load fine (the freshly-initialized prior is kept),
+        # and (b) an old action-decoder checkpoint can seed a brand-new source
+        # prior under mode != "gaussian".
+        if self.pipe.source_prior_has_params:
+            if len(_sp_state_dict) > 0:
+                sp_res = self.pipe.source_prior.load_state_dict(_sp_state_dict, strict=False)
+                log.info(
+                    f"Loaded source_prior: missing={len(sp_res.missing_keys)}, "
+                    f"unexpected={len(sp_res.unexpected_keys)}"
+                )
+            else:
+                log.warning("No source_prior.* weights in checkpoint; using freshly initialized source prior.")
+            if (
+                self.config.pipe_config.ema.enabled
+                and self.pipe.source_prior_ema is not None
+                and len(_sp_ema_state_dict) > 0
+            ):
+                self.pipe.source_prior_ema.load_state_dict(_sp_ema_state_dict, strict=False)
 
         state_dict = _reg_state_dict
 
@@ -589,8 +713,11 @@ class World2ActionModel(ImaginaireModel):
         error_if_nonfinite: bool = False,
         foreach: bool | None = None,
     ) -> torch.Tensor:
+        params = list(self.net.parameters())
+        if self.pipe.source_prior_has_params:
+            params = params + list(self.pipe.source_prior.parameters())
         return clip_grad_norm_(
-            self.net.parameters(),
+            params,
             max_norm,
             norm_type=norm_type,
             error_if_nonfinite=error_if_nonfinite,

--- a/model/cosmos_predict2/models/world2action_model.py
+++ b/model/cosmos_predict2/models/world2action_model.py
@@ -88,6 +88,15 @@ class World2ActionModelConfig:
     offline_video_latent_dir: str = ""
     offline_video_latent_required: bool = False
 
+    # Every N iterations, run the full sampling loop on the current train batch
+    # (GT-video conditioning) and log the unnormalized action MSE as
+    # `probe/sampled_action_mse_gtvid`. 0 disables. Run-1 lesson: LIBERO configs
+    # have run_validation=False, so without this probe there is NO
+    # scale-invariant, source-independent metric during training and a collapsed
+    # source prior stays invisible until sim eval (the flow loss is NOT
+    # comparable across source modes).
+    sampled_mse_probe_interval: int = 0
+
 
 def _dp_mean(x: torch.Tensor) -> torch.Tensor:
     if dist.is_available() and dist.is_initialized():
@@ -849,6 +858,44 @@ class World2ActionModel(ImaginaireModel):
                 f"local_bsz={B}",
                 flush=True,
             )
+
+        # VLSP collapse alarm (run-1 failure mode): logstd sinking toward the
+        # clamp floor means the source is degenerating into a Dirac. Warn early
+        # (-2.5 is far above the floor of logstd_min=-5), throttled by iteration.
+        if "logstd" in source_metrics and iteration % 1_000 == 0:
+            logstd_mean = float(source_metrics["logstd"].detach().mean().item())
+            if logstd_mean < -2.5:
+                log.warning(
+                    f"[VLSP] source prior variance collapsing: logstd_mean={logstd_mean:.3f} "
+                    f"(floor={self.pipe.config.action_source_prior.logstd_min}). "
+                    "Consider kl_weight>=1e-3, video_prior_blend, or a higher logstd_min."
+                )
+
+        # Scale-invariant training probe: full sampling on the current batch
+        # (GT-video conditioning) -> unnormalized action MSE. Unlike the flow
+        # loss this IS comparable across source modes and to the baseline.
+        # Runs on ALL ranks at the same iterations, so the _dp_mean collective
+        # inside is safe under DDP/FSDP.
+        probe_interval = getattr(self.config, "sampled_mse_probe_interval", 0)
+        if probe_interval and probe_interval > 0 and iteration > 0 and iteration % probe_interval == 0:
+            with torch.no_grad():
+                pred_B_HA_A = self.pipe(
+                    state_B_HO_O=data_batch["obs/lowdim_concat"],
+                    crossattn_emb=crossattn_emb,
+                    context_timesteps_B_1=video_sigma_B_1,
+                    seed=0,
+                    use_cuda_graphs=False,
+                )
+                probe_mse = F.mse_loss(
+                    pred_B_HA_A.float(), data_batch["action/lowdim_concat"].float()
+                )
+                probe_mse = _dp_mean(probe_mse.detach().clone())
+                if (
+                    not dist.is_available()
+                    or not dist.is_initialized()
+                    or parallel_state.get_data_parallel_rank() == 0
+                ):
+                    output_batch["probe/sampled_action_mse_gtvid"] = probe_mse.item()
 
         return output_batch, loss
 

--- a/model/cosmos_predict2/models/world2action_model.py
+++ b/model/cosmos_predict2/models/world2action_model.py
@@ -33,6 +33,7 @@ from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
 from torch.nn import functional as F
+from torch.nn.parameter import is_lazy
 from torch.nn.modules.module import _IncompatibleKeys
 
 from cosmos_predict2.conditioner import DataType
@@ -296,16 +297,51 @@ class World2ActionModel(ImaginaireModel):
             if self.pipe.source_prior_ema is not None:
                 self._update_source_prior_ema(ema_beta)
 
+    def on_after_backward(self, iteration: int = 0) -> None:
+        del iteration
+        if self.config.fsdp_shard_size != 0 and self.pipe.source_prior_has_params:
+            self._sync_source_prior_grads()
+
+    @torch.no_grad()
+    def _sync_source_prior_grads(self) -> None:
+        """Average replicated source-prior grads for FSDP-only runs."""
+        if not dist.is_available() or not dist.is_initialized():
+            return
+
+        group = getattr(self.pipe, "source_prior_dp_group", None)
+        if group is not None:
+            world = len(dist.get_process_group_ranks(group))
+        else:
+            try:
+                group = parallel_state.get_data_parallel_group()
+                world = parallel_state.get_data_parallel_world_size()
+            except Exception:
+                group = None
+                world = dist.get_world_size()
+
+        if world <= 1:
+            return
+
+        for param in self.pipe.source_prior.parameters():
+            if param.grad is None:
+                continue
+            dist.all_reduce(param.grad, op=dist.ReduceOp.SUM, group=group)
+            param.grad.div_(world)
+
     @torch.no_grad()
     def _update_source_prior_ema(self, beta: float) -> None:
         """Param-wise EMA for the VLSP source prior (weights = beta*ema + (1-beta)*new).
 
-        Implemented for the standard DDP / non-FSDP path. FSDP+EMA for the source
-        prior is not specially handled (the prior is small and left replicated);
-        see VLSP.md for the limitation.
+        Lazy language projection weights are materialized into the EMA copy on the
+        first update after the trainable source prior sees language inputs.
         """
+        if any(is_lazy(p) for p in self.pipe.source_prior_ema.parameters()):
+            self.pipe.source_prior_ema.load_state_dict(self.pipe.source_prior.state_dict(), strict=False)
+
         src_params = dict(self.pipe.source_prior.named_parameters())
         for name, p_ema in self.pipe.source_prior_ema.named_parameters():
+            if is_lazy(p_ema) or is_lazy(src_params[name]):
+                continue
             p_ema.mul_(beta).add_(src_params[name].detach(), alpha=1.0 - beta)
         src_buffers = dict(self.pipe.source_prior.named_buffers())
         for name, b_ema in self.pipe.source_prior_ema.named_buffers():

--- a/model/cosmos_predict2/pipelines/world2action.py
+++ b/model/cosmos_predict2/pipelines/world2action.py
@@ -24,6 +24,7 @@ from torch.distributed.fsdp import FSDPModule, fully_shard
 from cosmos_predict2.configs.config_world2action import (
     World2ActionPipelineConfig,
 )
+from cosmos_predict2.models.action_source_prior import ActionSourcePrior, apply_action_conditioning
 from cosmos_predict2.models.utils import init_weights_on_device, load_state_dict
 from cosmos_predict2.module.normalizer import StaticBatchNormalizer
 from cosmos_predict2.pipelines.base import BasePipeline
@@ -33,7 +34,7 @@ from cosmos_predict2.utils.dtensor_helper import (
     broadcast_dtensor_model_states,
 )
 from imaginaire.lazy_config import instantiate
-from imaginaire.utils import log, misc
+from imaginaire.utils import log
 from imaginaire.utils.ema import FastEmaModelUpdater
 
 
@@ -51,6 +52,11 @@ class World2ActionPipeline(BasePipeline):
         self.model_names = ["dit"]
         self.use_unified_sequence_parallel = False
         self.normalizer = StaticBatchNormalizer()
+        # VLSP: video-latent source prior (set in from_config). When VLSP is
+        # disabled this is an ActionSourcePrior with no parameters that simply
+        # reproduces the Gaussian source, so nothing downstream changes.
+        self.source_prior: ActionSourcePrior
+        self.source_prior_ema: ActionSourcePrior | None = None
 
     @staticmethod
     def from_config(
@@ -82,6 +88,12 @@ class World2ActionPipeline(BasePipeline):
             dit_config = config.net
             pipe.dit = instantiate(dit_config).eval()
 
+        # VLSP source-prior weights are stashed here (if present in the checkpoint)
+        # and loaded after the prior is constructed in step 4b below. This makes
+        # inference/eval (which load via from_config, not the training Model) pick
+        # up trained source-prior weights instead of leaving them random.
+        sp_state_dict: dict = {}
+        sp_ema_state_dict: dict = {}
         if dit_path:
             log.info(f"Loading DiT from {dit_path}")
             state_dict = load_state_dict(dit_path)
@@ -89,6 +101,10 @@ class World2ActionPipeline(BasePipeline):
             for k, v in state_dict.items():
                 if k.startswith("net."):
                     state_dict_dit_compatible[k[4:]] = v
+                elif k.startswith("source_prior_ema."):
+                    sp_ema_state_dict[k[len("source_prior_ema.") :]] = v
+                elif k.startswith("source_prior."):
+                    sp_state_dict[k[len("source_prior.") :]] = v
                 else:
                     state_dict_dit_compatible[k] = v
             pipe.dit.load_state_dict(state_dict_dit_compatible, strict=False, assign=True)
@@ -113,6 +129,45 @@ class World2ActionPipeline(BasePipeline):
             # copying is only necessary when starting the training at iteration 0.
             # Actual state_dict should be loaded after the pipe is created.
             pipe.dit_ema_worker.copy_to(src_model=pipe.dit, tgt_model=pipe.dit_ema)
+
+        # 4b. VLSP: build the action source prior. Dims are read from the action
+        # DiT config so the prior produces (B, HA, action_dim) in the same
+        # normalized action space the flow loss is computed on.
+        net_cfg = config.net
+        pipe.source_prior = ActionSourcePrior(
+            config.action_source_prior,
+            action_dim=int(net_cfg.out_channels),
+            video_emb_dim=int(net_cfg.crossattn_emb_channels),
+            state_dim=int(net_cfg.in_channels),
+            max_horizon=int(net_cfg.max_horizon),
+        ).to(device=device, dtype=dtype)
+
+        # Load trained source-prior weights from the checkpoint, if present
+        # (non-strict: old/baseline checkpoints simply have none).
+        if pipe.source_prior.has_trainable_params and len(sp_state_dict) > 0:
+            sp_res = pipe.source_prior.load_state_dict(sp_state_dict, strict=False)
+            log.success(
+                f"Loaded source_prior from checkpoint "
+                f"(missing={len(sp_res.missing_keys)}, unexpected={len(sp_res.unexpected_keys)})"
+            )
+        elif pipe.source_prior.has_trainable_params and dit_path:
+            log.warning("No source_prior.* weights found in checkpoint; source prior is randomly initialized.")
+
+        if config.ema.enabled and pipe.source_prior.has_trainable_params:
+            pipe.source_prior_ema = ActionSourcePrior(
+                config.action_source_prior,
+                action_dim=int(net_cfg.out_channels),
+                video_emb_dim=int(net_cfg.crossattn_emb_channels),
+                state_dim=int(net_cfg.in_channels),
+                max_horizon=int(net_cfg.max_horizon),
+            ).to(device=device, dtype=dtype)
+            if len(sp_ema_state_dict) > 0:
+                pipe.source_prior_ema.load_state_dict(sp_ema_state_dict, strict=False)
+            else:
+                pipe.source_prior_ema.load_state_dict(pipe.source_prior.state_dict())
+            pipe.source_prior_ema.requires_grad_(False)
+        else:
+            pipe.source_prior_ema = None
 
         pipe.dit = pipe.dit.to(device=device, dtype=dtype)
         torch.cuda.empty_cache()
@@ -141,6 +196,77 @@ class World2ActionPipeline(BasePipeline):
 
     def denoising_model(self) -> torch.nn.Module:
         return self.dit
+
+    # ------------------------------------------------------------------ #
+    #  VLSP: source prior + action conditioning                          #
+    # ------------------------------------------------------------------ #
+    @property
+    def source_prior_enabled(self) -> bool:
+        return bool(self.config.action_source_prior.enabled)
+
+    @property
+    def source_prior_has_params(self) -> bool:
+        return self.source_prior is not None and self.source_prior.has_trainable_params
+
+    def sample_action_source(
+        self,
+        *,
+        x0_shape: tuple[int, int, int] | torch.Size,
+        crossattn_emb: torch.Tensor | None,
+        state_B_HO_O: torch.Tensor | None,
+        context_timesteps_B_1: torch.Tensor | None,
+        x0_B_HA_A: torch.Tensor | None = None,
+        language_B_L_D: torch.Tensor | None = None,
+        training: bool = False,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        """Sample the flow-matching source endpoint (VLSP entry point).
+
+        ``source_mode="gaussian"`` reproduces the original baseline exactly. Other
+        modes derive the source from the video latent (see action_source_prior.py).
+        The returned source lives in the normalized action space.
+        """
+        return self.source_prior(
+            tuple(x0_shape),
+            crossattn_emb=crossattn_emb,
+            state_B_HO_O=state_B_HO_O,
+            context_timesteps_B_1=context_timesteps_B_1,
+            x0_B_HA_A=x0_B_HA_A,
+            language_B_L_D=language_B_L_D,
+            generator=generator,
+            training=training,
+            seed=seed,
+        )
+
+    def prepare_action_condition(
+        self,
+        crossattn_emb: torch.Tensor,
+        *,
+        mode: str | None = None,
+        training: bool = False,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Transform the video latent before it is fed to the action DiT.
+
+        This is *separate* from the source prior input so that e.g. the source can
+        use the real video latent while the decoder receives a zeroed or shuffled
+        condition. When VLSP is disabled the condition is always passed through
+        unchanged (exact baseline behaviour).
+        """
+        if not self.source_prior_enabled:
+            return crossattn_emb
+        if mode is None:
+            mode = self.config.action_conditioning.mode
+        return apply_action_conditioning(
+            crossattn_emb,
+            mode=mode,
+            dropout_prob=float(self.config.action_conditioning.dropout_prob),
+            seed=seed,
+            generator=generator,
+            training=training,
+        )
 
     def denoise(
         self,
@@ -210,11 +336,27 @@ class World2ActionPipeline(BasePipeline):
         if HO > 0:
             state_B_HO_O = self.normalizer.norms["obs/lowdim_concat"](state_B_HO_O)
 
-        sample_B_HA_A = misc.arch_invariant_rand(
-            (B, HA, self.dit.out_channels),
-            **self.tensor_kwargs,
+        # VLSP: the source endpoint of the action flow. With source_mode="gaussian"
+        # this is identical to the original misc.arch_invariant_rand(seed=...) draw.
+        sample_B_HA_A, _source_metrics = self.sample_action_source(
+            x0_shape=(B, HA, self.dit.out_channels),
+            crossattn_emb=crossattn_emb,
+            state_B_HO_O=state_B_HO_O,
+            context_timesteps_B_1=context_timesteps_B_1,
+            x0_B_HA_A=None,
+            training=False,
             seed=seed,
         )
+        sample_B_HA_A = sample_B_HA_A.to(**self.tensor_kwargs)
+
+        # VLSP: optionally zero/shuffle the video condition fed to the action DiT
+        # (no-op when action_conditioning.mode == "normal" or VLSP disabled).
+        crossattn_for_action = self.prepare_action_condition(
+            crossattn_emb,
+            training=False,
+            seed=seed,
+        )
+
         timestep_B_HA_1 = torch.ones(
             (B, HA, 1),
             dtype=torch.float32,
@@ -226,7 +368,7 @@ class World2ActionPipeline(BasePipeline):
                 sample_B_HA_A,
                 timestep_B_HA_1,
                 state_B_HO_O,
-                crossattn_emb,
+                crossattn_for_action,
                 context_timesteps_B_1,
                 obs_dropout=0.0,
                 use_cuda_graphs=use_cuda_graphs,

--- a/model/cosmos_predict2/pipelines/world2action.py
+++ b/model/cosmos_predict2/pipelines/world2action.py
@@ -20,6 +20,7 @@ import torch
 from megatron.core import parallel_state
 from torch.distributed.device_mesh import DeviceMesh
 from torch.distributed.fsdp import FSDPModule, fully_shard
+from torch.nn.parameter import is_lazy
 
 from cosmos_predict2.configs.config_world2action import (
     World2ActionPipelineConfig,
@@ -57,6 +58,7 @@ class World2ActionPipeline(BasePipeline):
         # reproduces the Gaussian source, so nothing downstream changes.
         self.source_prior: ActionSourcePrior
         self.source_prior_ema: ActionSourcePrior | None = None
+        self.source_prior_dp_group = None
 
     @staticmethod
     def from_config(
@@ -184,6 +186,13 @@ class World2ActionPipeline(BasePipeline):
         self.dit.fully_shard(mesh=dp_mesh)
         self.dit = fully_shard(self.dit, mesh=dp_mesh, reshard_after_forward=True)
         broadcast_dtensor_model_states(self.dit, dp_mesh)
+        if self.source_prior_has_params:
+            # The source prior is intentionally small and replicated. Broadcast it
+            # here because FSDP runs are not wrapped in outer DDP.
+            self.source_prior_dp_group = dp_mesh.get_group("replicate")
+            broadcast_dtensor_model_states(self.source_prior, dp_mesh)
+            if self.source_prior_ema is not None:
+                broadcast_dtensor_model_states(self.source_prior_ema, dp_mesh)
         if self.dit_ema:
             self.dit_ema.fully_shard(mesh=dp_mesh)
             self.dit_ema = fully_shard(self.dit_ema, mesh=dp_mesh, reshard_after_forward=True)
@@ -381,8 +390,41 @@ class World2ActionPipeline(BasePipeline):
 
         return self.normalizer.norms["action/lowdim_concat"].unnormalize(sample_B_HA_A)
 
+    @staticmethod
+    @torch.no_grad()
+    def _cache_module_states(module: torch.nn.Module, is_cpu: bool = False) -> tuple[list[torch.Tensor | None], list[torch.Tensor]]:
+        device = "cpu" if is_cpu else None
+        params = [
+            None if is_lazy(param) else param.detach().clone().to(device=device)
+            for param in module.parameters()
+        ]
+        buffers = [buf.detach().clone().to(device=device) for buf in module.buffers()]
+        return params, buffers
+
+    @staticmethod
+    @torch.no_grad()
+    def _copy_module_states(src_model: torch.nn.Module, tgt_model: torch.nn.Module) -> None:
+        for src_param, tgt_param in zip(src_model.parameters(), tgt_model.parameters(), strict=False):
+            if is_lazy(src_param) or is_lazy(tgt_param):
+                continue
+            tgt_param.copy_(src_param.to(device=tgt_param.device, dtype=tgt_param.dtype))
+        for src_buf, tgt_buf in zip(src_model.buffers(), tgt_model.buffers(), strict=False):
+            tgt_buf.copy_(src_buf.to(device=tgt_buf.device, dtype=tgt_buf.dtype))
+
+    @staticmethod
+    @torch.no_grad()
+    def _restore_module_states(module: torch.nn.Module, states: tuple[list[torch.Tensor | None], list[torch.Tensor]]) -> None:
+        params, buffers = states
+        for cached, param in zip(params, module.parameters(), strict=False):
+            if cached is None:
+                continue
+            param.copy_(cached.to(device=param.device, dtype=param.dtype))
+        for cached, buf in zip(buffers, module.buffers(), strict=False):
+            buf.copy_(cached.to(device=buf.device, dtype=buf.dtype))
+
     @contextmanager
     def ema_scope(self, context: None, is_cpu: bool = False):
+        source_prior_cache = None
         if self.config.ema.enabled:
             # https://github.com/pytorch/pytorch/issues/144289
             for module in self.dit.modules():
@@ -390,6 +432,9 @@ class World2ActionPipeline(BasePipeline):
                     module.reshard()
             self.dit_ema_worker.cache(self.dit.parameters(), is_cpu=is_cpu)
             self.dit_ema_worker.copy_to(src_model=self.dit_ema, tgt_model=self.dit)
+            if self.source_prior_ema is not None:
+                source_prior_cache = self._cache_module_states(self.source_prior, is_cpu=is_cpu)
+                self._copy_module_states(self.source_prior_ema, self.source_prior)
             if context is not None:
                 log.info(f"{context}: Switched to EMA weights")
         try:
@@ -400,5 +445,7 @@ class World2ActionPipeline(BasePipeline):
                     if isinstance(module, FSDPModule):
                         module.reshard()
                 self.dit_ema_worker.restore(self.dit.parameters())
+                if source_prior_cache is not None:
+                    self._restore_module_states(self.source_prior, source_prior_cache)
                 if context is not None:
                     log.info(f"{context}: Restored training weights")

--- a/model/imaginaire/trainer.py
+++ b/model/imaginaire/trainer.py
@@ -19,6 +19,7 @@ import inspect
 import itertools as it
 import os
 import signal
+import time
 
 import torch
 import torch.distributed as dist
@@ -136,11 +137,48 @@ class ImaginaireTrainer:
             )
         # Initialize the timer for speed benchmarking.
         self.training_timer = misc.TrainingTimer()
+        self.debug_step_timing = os.environ.get("DEBUG_STEP_TIMING", "0").lower() in {"1", "true", "yes", "on"}
+        self.debug_step_timing_interval = max(1, int(os.environ.get("DEBUG_STEP_TIMING_INTERVAL", "10")))
+        self.debug_step_timing_all_ranks = os.environ.get("DEBUG_STEP_TIMING_ALL_RANKS", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        self._debug_step_timing_current: dict[str, float] | None = None
         # Send a TimeoutError if a training step takes over timeout_period seconds.
         signal.signal(
             signal.SIGALRM,
             functools.partial(misc.timeout_handler, config.trainer.timeout_period),
         )
+
+    def _debug_timing_rank(self) -> int:
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank()
+        return 0
+
+    def _debug_timing_world_size(self) -> int:
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_world_size()
+        return 1
+
+    def _debug_timing_should_log(self, iteration: int) -> bool:
+        if not self.debug_step_timing:
+            return False
+        if iteration % self.debug_step_timing_interval != 0:
+            return False
+        return self.debug_step_timing_all_ranks or self._debug_timing_rank() == 0
+
+    def _debug_timing_cuda_sync(self) -> None:
+        if self.debug_step_timing and torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+    @staticmethod
+    def _debug_infer_local_batch_size(data_batch: dict[str, torch.Tensor], fallback: int | None = None) -> int | None:
+        for value in data_batch.values():
+            if torch.is_tensor(value) and value.ndim > 0:
+                return int(value.shape[0])
+        return fallback
 
     def train(
         self,
@@ -207,6 +245,9 @@ class ImaginaireTrainer:
                 dataloader_train_iter = iter(dataloader_train)
                 while True:
                     self.callbacks.on_before_dataloading(iteration)
+                    debug_timing_active = self.debug_step_timing
+                    debug_total_t0 = time.perf_counter() if debug_timing_active else None
+                    debug_data_t0 = time.perf_counter() if debug_timing_active else None
                     try:
                         with self.training_timer("dataloader_train"):
                             data_batch = next(dataloader_train_iter)
@@ -214,12 +255,22 @@ class ImaginaireTrainer:
                         break
                     finally:
                         self.callbacks.on_after_dataloading(iteration)
+                    debug_times: dict[str, float] = {}
+                    if debug_timing_active and debug_data_t0 is not None:
+                        debug_times["data_time"] = time.perf_counter() - debug_data_t0
                     # If max_iter is reached, exit the training loop.
                     if iteration >= self.config.trainer.max_iter:
                         _end_training = True
                         break
                     # Move all tensors in the data batch to GPU device.
+                    if debug_timing_active:
+                        self._debug_timing_cuda_sync()
+                        debug_h2d_t0 = time.perf_counter()
                     data_batch = misc.to(data_batch, device="cuda")
+                    if debug_timing_active:
+                        self._debug_timing_cuda_sync()
+                        debug_times["h2d_time"] = time.perf_counter() - debug_h2d_t0
+                        self._debug_step_timing_current = debug_times
                     # The actual training step.
                     self.callbacks.on_training_step_start(model, data_batch, iteration=iteration)
                     self.callbacks.on_training_step_batch_start(model, data_batch, iteration=iteration)
@@ -236,6 +287,27 @@ class ImaginaireTrainer:
                         iteration=iteration,
                         grad_accum_iter=grad_accum_iter,
                     )
+                    if debug_timing_active and debug_total_t0 is not None:
+                        self._debug_timing_cuda_sync()
+                        debug_times["total_step_time"] = time.perf_counter() - debug_total_t0
+                        if grad_accum_iter == 0 and self._debug_timing_should_log(iteration):
+                            local_bsz = self._debug_infer_local_batch_size(data_batch, dataloader_train.batch_size)
+                            world_size = self._debug_timing_world_size()
+                            global_bsz = None if local_bsz is None else local_bsz * world_size
+                            log.info(
+                                "[TIMING]"
+                                f"[rank={self._debug_timing_rank()}]"
+                                f"[step={iteration}] "
+                                f"data={debug_times.get('data_time', 0.0):.3f}s "
+                                f"h2d={debug_times.get('h2d_time', 0.0):.3f}s "
+                                f"fwd={debug_times.get('forward_time', 0.0):.3f}s "
+                                f"bwd={debug_times.get('backward_time', 0.0):.3f}s "
+                                f"opt={debug_times.get('optimizer_step_time', 0.0):.3f}s "
+                                f"zero_grad={debug_times.get('zero_grad_time', 0.0):.3f}s "
+                                f"total={debug_times.get('total_step_time', 0.0):.3f}s "
+                                f"local_bsz={local_bsz} global_bsz={global_bsz}"
+                            )
+                        self._debug_step_timing_current = None
                     self.callbacks.on_training_step_batch_end(
                         model, data_batch, output_batch, loss, iteration=iteration
                     )
@@ -320,12 +392,22 @@ class ImaginaireTrainer:
             loss (torch.Tensor): The total loss of the training data batch.
         """
         # Only let DDP sync gradient at the last iteration of the gradient accumulation window
+        debug_times = self._debug_step_timing_current
         with distributed.ddp_sync_grad(model_ddp, grad_accum_iter == self.config.trainer.grad_accum_iter - 1):
             self.callbacks.on_before_forward(iteration=iteration)
+            if debug_times is not None:
+                self._debug_timing_cuda_sync()
+                debug_forward_t0 = time.perf_counter()
             with self.training_timer("forward"):
                 output_batch, loss = model_ddp.training_step(data, iteration)
+            if debug_times is not None:
+                self._debug_timing_cuda_sync()
+                debug_times["forward_time"] = time.perf_counter() - debug_forward_t0
             self.callbacks.on_after_forward(iteration=iteration)
             self.callbacks.on_before_backward(model_ddp, loss, iteration=iteration)
+            if debug_times is not None:
+                self._debug_timing_cuda_sync()
+                debug_backward_t0 = time.perf_counter()
             with self.training_timer("backward"):
                 loss_scaled = grad_scaler.scale(loss / self.config.trainer.grad_accum_iter)
                 loss_scaled.backward()
@@ -333,22 +415,35 @@ class ImaginaireTrainer:
                     model_ddp.module.on_after_backward()
                 else:
                     model_ddp.on_after_backward()
+            if debug_times is not None:
+                self._debug_timing_cuda_sync()
+                debug_times["backward_time"] = time.perf_counter() - debug_backward_t0
             self.callbacks.on_after_backward(model_ddp, iteration=iteration)
         grad_accum_iter += 1
         if grad_accum_iter == self.config.trainer.grad_accum_iter:
             with self.training_timer("optimizer_step"):
+                if debug_times is not None:
+                    self._debug_timing_cuda_sync()
+                    debug_optimizer_t0 = time.perf_counter()
                 self.callbacks.on_before_optimizer_step(
                     model_ddp, optimizer, scheduler, grad_scaler, iteration=iteration
                 )
                 grad_scaler.step(optimizer)
                 grad_scaler.update()
                 scheduler.step()
+                if debug_times is not None:
+                    self._debug_timing_cuda_sync()
+                    debug_times["optimizer_step_time"] = time.perf_counter() - debug_optimizer_t0
+                    debug_zero_t0 = time.perf_counter()
                 self.callbacks.on_before_zero_grad(model_ddp, optimizer, scheduler, iteration=iteration)
                 if self.config.trainer.distributed_parallelism == "ddp":
                     model_ddp.module.on_before_zero_grad(optimizer, scheduler, iteration=iteration)
                 else:
                     model_ddp.on_before_zero_grad(optimizer, scheduler, iteration=iteration)
                 optimizer.zero_grad(set_to_none=True)
+                if debug_times is not None:
+                    self._debug_timing_cuda_sync()
+                    debug_times["zero_grad_time"] = time.perf_counter() - debug_zero_t0
             grad_accum_iter = 0
         return output_batch, loss, grad_accum_iter
 

--- a/model/imaginaire/utils/distributed.py
+++ b/model/imaginaire/utils/distributed.py
@@ -58,6 +58,11 @@ def init() -> int | None:
     # Set GPU affinity.
     pynvml.nvmlInit()
     local_rank = int(os.getenv("LOCAL_RANK", 0))
+    cuda_local_rank = local_rank
+    if torch.cuda.is_available():
+        cuda_device_count = torch.cuda.device_count()
+        if cuda_device_count > 0 and cuda_local_rank >= cuda_device_count:
+            cuda_local_rank = 0
     try:
         device = Device(local_rank)
         os.sched_setaffinity(0, device.get_cpu_affinity())
@@ -67,16 +72,22 @@ def init() -> int | None:
     os.environ["TORCH_NCCL_BLOCKING_WAIT"] = "0"
     os.environ["TORCH_NCCL_ASYNC_ERROR_HANDLING"] = "1"
     if dist.is_available():
-        torch.cuda.set_device(local_rank)
+        torch.cuda.set_device(cuda_local_rank)
         # Get the timeout value from environment variable
         timeout_seconds = os.getenv("TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC", 1800)
         # Convert the timeout to an integer (if it isn't already) and then to a timedelta
         timeout_timedelta = timedelta(seconds=int(timeout_seconds))
-        dist.init_process_group(
-            backend="nccl", init_method="env://", timeout=timeout_timedelta
-        )
+        backend = os.getenv("MIMIC_DISTRIBUTED_BACKEND", "nccl")
+        init_kwargs = dict(backend=backend, init_method="env://", timeout=timeout_timedelta)
+        if backend == "nccl":
+            try:
+                dist.init_process_group(**init_kwargs, device_id=torch.device(f"cuda:{cuda_local_rank}"))
+            except TypeError:
+                dist.init_process_group(**init_kwargs)
+        else:
+            dist.init_process_group(**init_kwargs)
         log.info(
-            f"Initialized distributed training with local rank {local_rank} with timeout {timeout_seconds}",
+            f"Initialized distributed training with local rank {local_rank}, cuda device {cuda_local_rank} with timeout {timeout_seconds}",
             rank0_only=False,
         )
     # Increase the L2 fetch granularity for faster speed.
@@ -207,6 +218,11 @@ def parallel_model_wrapper(
     """
     if dist.is_available() and dist.is_initialized():
         local_rank = int(os.getenv("LOCAL_RANK", 0))
+        cuda_local_rank = local_rank
+        if torch.cuda.is_available():
+            cuda_device_count = torch.cuda.device_count()
+            if cuda_device_count > 0 and cuda_local_rank >= cuda_device_count:
+                cuda_local_rank = 0
         try:
             ddp_group = parallel_state.get_data_parallel_group(
                 with_context_parallel=with_cp
@@ -220,8 +236,8 @@ def parallel_model_wrapper(
 
         model = DistributedDataParallel(
             model,
-            device_ids=[local_rank],
-            output_device=local_rank,
+            device_ids=[cuda_local_rank],
+            output_device=cuda_local_rank,
             find_unused_parameters=config_ddp.find_unused_parameters,
             static_graph=config_ddp.static_graph,
             broadcast_buffers=config_ddp.broadcast_buffers,

--- a/model/scripts/debug_vlsp.py
+++ b/model/scripts/debug_vlsp.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Lightweight smoke test for VLSP (Video-Latent Source Prior).
+
+Exercises the source-prior module + action-conditioning helpers with fake
+tensors -- no GPU / transformer-engine / dataset required.  Run with:
+
+    python -m scripts.debug_vlsp
+
+It checks:
+  1. the prior instantiates and returns sources of shape [B, HA, A];
+  2. ``gaussian`` works without any video latent;
+  3. ``video_prior_sample`` works with a fake crossattn_emb;
+  4. ``zero_video`` / ``shuffled_video`` conditioning preserve shape;
+  5. ``video_prior_mean`` is deterministic for equal inputs;
+  6. source-prior checkpoints round-trip and old (empty) checkpoints load when
+     the prior is disabled.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from cosmos_predict2.models.action_source_prior import (
+    ActionSourcePrior,
+    apply_action_conditioning,
+    compute_prior_regularization,
+)
+
+# The real attrs config requires the hydra/omegaconf stack; fall back to a tiny
+# duck-typed stand-in so this smoke test runs in a minimal (CPU-only) env too.
+try:  # pragma: no cover - depends on environment
+    from cosmos_predict2.configs.config_world2action import ActionSourcePriorConfig
+
+    def make_cfg(**kw):
+        return ActionSourcePriorConfig(**kw)
+
+except Exception:  # noqa: BLE001
+    from dataclasses import dataclass, fields
+
+    @dataclass
+    class _Cfg:
+        enabled: bool = False
+        mode: str = "gaussian"
+        pool_type: str = "mean"
+        hidden_dim: int = 256
+        num_perceiver_latents: int = 8
+        num_attention_heads: int = 8
+        mlp_depth: int = 2
+        logstd_min: float = -5.0
+        logstd_max: float = 1.0
+        init_logstd: float = -1.0
+        residual_scale: float = 1.0
+        blend_alpha: float = 1.0
+        source_dropout_prob: float = 0.0
+        dropout_granularity: str = "sample"
+        sampling_temperature: float = 1.0
+        detach_video_latents: bool = True
+        use_state: bool = True
+        use_context_timestep: bool = True
+        use_language: bool = False
+        kl_weight: float = 0.0
+        mean_l2_weight: float = 0.0
+        std_reg_weight: float = 0.0
+        debug_noise_std: float = 0.05
+
+    def make_cfg(**kw):
+        valid = {f.name for f in fields(_Cfg)}
+        return _Cfg(**{k: v for k, v in kw.items() if k in valid})
+
+
+B, HO, HA, A, D = 2, 1, 15, 10, 2048
+SHAPE = (B, HA, A)
+MAX_HORIZON = 61
+
+
+def _build(**kw) -> ActionSourcePrior:
+    cfg = make_cfg(hidden_dim=128, num_attention_heads=4, **kw)
+    return ActionSourcePrior(cfg, action_dim=A, video_emb_dim=D, state_dim=A, max_horizon=MAX_HORIZON)
+
+
+def _fake_inputs():
+    g = torch.Generator().manual_seed(0)
+    crossattn = torch.randn(B, 7 * 5 * 5, D, generator=g)
+    state = torch.randn(B, HO, A, generator=g)
+    ctx_t = torch.rand(B, 1, generator=g) * 100.0
+    x0 = torch.randn(B, HA, A, generator=g)
+    return crossattn, state, ctx_t, x0
+
+
+def main() -> None:
+    torch.manual_seed(0)
+    crossattn, state, ctx_t, x0 = _fake_inputs()
+
+    # 1 + 3. gaussian works without any video latent.
+    prior = _build(enabled=False, mode="gaussian")
+    source, metrics = prior(
+        SHAPE, crossattn_emb=None, state_B_HO_O=None, context_timesteps_B_1=None, x0_B_HA_A=None, training=True
+    )
+    assert source.shape == SHAPE == x0.shape, source.shape
+    assert torch.isfinite(source).all()
+    assert sum(p.numel() for p in prior.parameters()) == 0, "disabled prior must carry no params"
+    print("[1/7] gaussian (disabled) -> shape", tuple(source.shape), "OK")
+
+    # gaussian determinism via seed (inference path uses arch_invariant_rand).
+    s1, _ = prior(SHAPE, crossattn_emb=None, state_B_HO_O=None, context_timesteps_B_1=None, training=False, seed=3)
+    s2, _ = prior(SHAPE, crossattn_emb=None, state_B_HO_O=None, context_timesteps_B_1=None, training=False, seed=3)
+    assert torch.equal(s1, s2)
+    print("[2/7] gaussian seeded determinism OK")
+
+    # 4. video_prior_sample works with a fake crossattn_emb.
+    prior = _build(enabled=True, mode="video_prior_sample", pool_type="attention")
+    source, metrics = prior(
+        SHAPE,
+        crossattn_emb=crossattn,
+        state_B_HO_O=state,
+        context_timesteps_B_1=ctx_t,
+        x0_B_HA_A=x0,
+        training=True,
+    )
+    assert source.shape == SHAPE and torch.isfinite(source).all()
+    loss_prior, logs = compute_prior_regularization(metrics, prior.cfg)
+    print("[3/7] video_prior_sample -> shape", tuple(source.shape), "metrics:", sorted(metrics))
+
+    # pred shape sanity: u_t = source - x0 has the same shape as x0.
+    pred_like = source - x0
+    assert pred_like.shape == x0.shape
+    print("[4/7] u_t = source - x0 shape", tuple(pred_like.shape), "OK")
+
+    # 5. zero_video / shuffled_video conditioning preserve shape.
+    zero_c = apply_action_conditioning(crossattn, mode="zero_video")
+    shuf_c = apply_action_conditioning(crossattn, mode="shuffled_video", seed=1)
+    norm_c = apply_action_conditioning(crossattn, mode="normal")
+    assert zero_c.shape == shuf_c.shape == norm_c.shape == crossattn.shape
+    assert torch.count_nonzero(zero_c) == 0
+    assert torch.equal(norm_c, crossattn)
+    print("[5/7] zero_video / shuffled_video conditioning preserve shape OK")
+
+    # 6. video_prior_mean is deterministic for equal inputs.
+    prior = _build(enabled=True, mode="video_prior_mean", pool_type="mean")
+    m1, _ = prior(SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, training=False, seed=7)
+    m2, _ = prior(
+        SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, training=False, seed=123
+    )
+    assert torch.equal(m1, m2), "video_prior_mean must be deterministic regardless of seed"
+    print("[6/7] video_prior_mean determinism OK")
+
+    # 7. checkpoint round-trip + old/empty checkpoint into a disabled prior.
+    enabled = _build(enabled=True, mode="video_prior_sample")
+    sd = enabled.state_dict()
+    reloaded = _build(enabled=True, mode="video_prior_sample")
+    reloaded.load_state_dict(sd)
+    disabled = _build(enabled=False, mode="gaussian")
+    res = disabled.load_state_dict({}, strict=False)
+    assert len(res.missing_keys) == 0 and len(res.unexpected_keys) == 0
+    print(f"[7/7] ckpt round-trip ({len(sd)} keys) + empty-load-into-disabled OK")
+
+    # extra: every video mode x pool is finite and correctly shaped.
+    for mode in [
+        "video_prior_sample",
+        "video_prior_mean",
+        "video_prior_residual",
+        "video_prior_blend",
+        "video_prior_dropout",
+        "shuffled_video_prior",
+    ]:
+        for pool in ["mean", "attention", "perceiver"]:
+            p = _build(
+                enabled=True,
+                mode=mode,
+                pool_type=pool,
+                blend_alpha=0.5,
+                source_dropout_prob=0.3,
+                dropout_granularity="element",
+                kl_weight=0.1,
+                mean_l2_weight=0.1,
+                std_reg_weight=0.1,
+            )
+            s, met = p(
+                SHAPE,
+                crossattn_emb=crossattn,
+                state_B_HO_O=state,
+                context_timesteps_B_1=ctx_t,
+                x0_B_HA_A=x0,
+                training=True,
+            )
+            assert s.shape == SHAPE and torch.isfinite(s).all(), (mode, pool)
+            reg, _ = compute_prior_regularization(met, p.cfg)
+            assert torch.is_tensor(reg) and torch.isfinite(reg).all(), (mode, pool)
+    print("[extra] all 6 video modes x 3 pools + regularizers finite OK")
+
+    print("\nALL VLSP SMOKE TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/model/scripts/debug_vlsp.py
+++ b/model/scripts/debug_vlsp.py
@@ -13,10 +13,12 @@ tensors -- no GPU / transformer-engine / dataset required.  Run with:
 It checks:
   1. the prior instantiates and returns sources of shape [B, HA, A];
   2. ``gaussian`` works without any video latent;
-  3. ``video_prior_sample`` works with a fake crossattn_emb;
-  4. ``zero_video`` / ``shuffled_video`` conditioning preserve shape;
-  5. ``video_prior_mean`` is deterministic for equal inputs;
-  6. source-prior checkpoints round-trip and old (empty) checkpoints load when
+  3. ``enabled=true, mode=gaussian`` is rejected as ambiguous;
+  4. ``video_prior_sample`` works with a fake crossattn_emb;
+  5. ``zero_video`` / ``shuffled_video`` conditioning preserve shape;
+  6. ``video_prior_mean`` is deterministic for equal inputs;
+  7. language-prior first-use and missing-language fallback are explicit;
+  8. source-prior checkpoints round-trip and old (empty) checkpoints load when
      the prior is disabled.
 """
 
@@ -103,13 +105,20 @@ def main() -> None:
     assert source.shape == SHAPE == x0.shape, source.shape
     assert torch.isfinite(source).all()
     assert sum(p.numel() for p in prior.parameters()) == 0, "disabled prior must carry no params"
-    print("[1/7] gaussian (disabled) -> shape", tuple(source.shape), "OK")
+    print("[1/9] gaussian (disabled) -> shape", tuple(source.shape), "OK")
+
+    try:
+        _build(enabled=True, mode="gaussian")
+        raise AssertionError("enabled=true with gaussian mode must be rejected")
+    except ValueError:
+        pass
+    print("[2/9] enabled=true + gaussian mode rejected OK")
 
     # gaussian determinism via seed (inference path uses arch_invariant_rand).
     s1, _ = prior(SHAPE, crossattn_emb=None, state_B_HO_O=None, context_timesteps_B_1=None, training=False, seed=3)
     s2, _ = prior(SHAPE, crossattn_emb=None, state_B_HO_O=None, context_timesteps_B_1=None, training=False, seed=3)
     assert torch.equal(s1, s2)
-    print("[2/7] gaussian seeded determinism OK")
+    print("[3/9] gaussian seeded determinism OK")
 
     # 4. video_prior_sample works with a fake crossattn_emb.
     prior = _build(enabled=True, mode="video_prior_sample", pool_type="attention")
@@ -123,12 +132,12 @@ def main() -> None:
     )
     assert source.shape == SHAPE and torch.isfinite(source).all()
     loss_prior, logs = compute_prior_regularization(metrics, prior.cfg)
-    print("[3/7] video_prior_sample -> shape", tuple(source.shape), "metrics:", sorted(metrics))
+    print("[4/9] video_prior_sample -> shape", tuple(source.shape), "metrics:", sorted(metrics))
 
     # pred shape sanity: u_t = source - x0 has the same shape as x0.
     pred_like = source - x0
     assert pred_like.shape == x0.shape
-    print("[4/7] u_t = source - x0 shape", tuple(pred_like.shape), "OK")
+    print("[5/9] u_t = source - x0 shape", tuple(pred_like.shape), "OK")
 
     # 5. zero_video / shuffled_video conditioning preserve shape.
     zero_c = apply_action_conditioning(crossattn, mode="zero_video")
@@ -137,7 +146,7 @@ def main() -> None:
     assert zero_c.shape == shuf_c.shape == norm_c.shape == crossattn.shape
     assert torch.count_nonzero(zero_c) == 0
     assert torch.equal(norm_c, crossattn)
-    print("[5/7] zero_video / shuffled_video conditioning preserve shape OK")
+    print("[6/9] zero_video / shuffled_video conditioning preserve shape OK")
 
     # 6. video_prior_mean is deterministic for equal inputs.
     prior = _build(enabled=True, mode="video_prior_mean", pool_type="mean")
@@ -146,9 +155,22 @@ def main() -> None:
         SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, training=False, seed=123
     )
     assert torch.equal(m1, m2), "video_prior_mean must be deterministic regardless of seed"
-    print("[6/7] video_prior_mean determinism OK")
+    print("[7/9] video_prior_mean determinism OK")
 
-    # 7. checkpoint round-trip + old/empty checkpoint into a disabled prior.
+    # use_language=True requires language on first forward, then tolerates missing
+    # language later while keeping lang_proj in the autograd graph.
+    prior = _build(enabled=True, mode="video_prior_mean", use_language=True)
+    try:
+        prior(SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, training=True)
+        raise AssertionError("use_language=True must require language on the first forward")
+    except ValueError:
+        pass
+    lang = torch.randn(B, 4, 32)
+    prior(SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, language_B_L_D=lang, training=True)
+    prior(SHAPE, crossattn_emb=crossattn, state_B_HO_O=state, context_timesteps_B_1=ctx_t, training=True)
+    print("[8/9] language prior initialization + missing-language fallback OK")
+
+    # 9. checkpoint round-trip + old/empty checkpoint into a disabled prior.
     enabled = _build(enabled=True, mode="video_prior_sample")
     sd = enabled.state_dict()
     reloaded = _build(enabled=True, mode="video_prior_sample")
@@ -156,7 +178,7 @@ def main() -> None:
     disabled = _build(enabled=False, mode="gaussian")
     res = disabled.load_state_dict({}, strict=False)
     assert len(res.missing_keys) == 0 and len(res.unexpected_keys) == 0
-    print(f"[7/7] ckpt round-trip ({len(sd)} keys) + empty-load-into-disabled OK")
+    print(f"[9/9] ckpt round-trip ({len(sd)} keys) + empty-load-into-disabled OK")
 
     # extra: every video mode x pool is finite and correctly shaped.
     for mode in [

--- a/model/scripts/vlsp_audit_config.py
+++ b/model/scripts/vlsp_audit_config.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve VLSP experiment configs for Phase-0 eval/config parity audits.
+
+Example:
+    python -m scripts.vlsp_audit_config \
+        --experiments vlsp_source_only_sample vlsp_source_condition_sample vlsp_baseline_gaussian \
+        --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+import types
+from collections import OrderedDict
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import attrs
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+
+DEFAULT_EXPERIMENTS = [
+    "vlsp_source_only_sample",
+    "vlsp_source_condition_sample",
+    "vlsp_baseline_gaussian",
+]
+
+
+def _install_config_import_stubs() -> None:
+    """Keep config resolution CPU-only when optional media deps are absent."""
+    if "imageio" not in sys.modules:
+        imageio_stub = types.ModuleType("imageio")
+        imageio_stub.__path__ = []
+        sys.modules["imageio"] = imageio_stub
+    if "imageio.v3" not in sys.modules:
+        sys.modules["imageio.v3"] = types.ModuleType("imageio.v3")
+    if "megatron" not in sys.modules:
+        megatron_stub = types.ModuleType("megatron")
+        megatron_stub.__path__ = []
+        sys.modules["megatron"] = megatron_stub
+    if "megatron.core" not in sys.modules:
+        core_stub = types.ModuleType("megatron.core")
+        core_stub.__path__ = []
+        sys.modules["megatron.core"] = core_stub
+    if "megatron.core.parallel_state" not in sys.modules:
+        parallel_state_stub = types.ModuleType("megatron.core.parallel_state")
+        parallel_state_stub.get_data_parallel_world_size = lambda: 1
+        parallel_state_stub.get_data_parallel_rank = lambda: 0
+        parallel_state_stub.is_initialized = lambda: False
+        sys.modules["megatron.core.parallel_state"] = parallel_state_stub
+        sys.modules["megatron.core"].parallel_state = parallel_state_stub
+    if "decord" not in sys.modules:
+        decord_stub = types.ModuleType("decord")
+
+        class _VideoReader:  # pragma: no cover - import-only stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("decord is not available in this CPU-only config audit environment")
+
+        decord_stub.VideoReader = _VideoReader
+        decord_stub.cpu = lambda *args, **kwargs: None
+        sys.modules["decord"] = decord_stub
+    if "transformers" not in sys.modules:
+        transformers_stub = types.ModuleType("transformers")
+        transformers_stub.__path__ = []
+
+        class _UnavailableTransformer:  # pragma: no cover - import-only stub
+            @classmethod
+            def from_pretrained(cls, *args: Any, **kwargs: Any) -> "_UnavailableTransformer":
+                raise RuntimeError("transformers is not available in this CPU-only config audit environment")
+
+        transformers_stub.T5EncoderModel = _UnavailableTransformer
+        transformers_stub.T5TokenizerFast = _UnavailableTransformer
+        sys.modules["transformers"] = transformers_stub
+    if "transformers.utils" not in sys.modules:
+        utils_stub = types.ModuleType("transformers.utils")
+        utils_stub.__path__ = []
+        sys.modules["transformers.utils"] = utils_stub
+        sys.modules["transformers"].utils = utils_stub
+    if "transformers.utils.logging" not in sys.modules:
+        logging_stub = types.ModuleType("transformers.utils.logging")
+        logging_stub.set_verbosity_error = lambda: None
+        sys.modules["transformers.utils.logging"] = logging_stub
+        sys.modules["transformers.utils"].logging = logging_stub
+    if "apex" not in sys.modules:
+        apex_stub = types.ModuleType("apex")
+        apex_stub.__path__ = []
+        sys.modules["apex"] = apex_stub
+    if "apex.multi_tensor_apply" not in sys.modules:
+        multi_tensor_apply_stub = types.ModuleType("apex.multi_tensor_apply")
+
+        class _MultiTensorApplier:  # pragma: no cover - import-only stub
+            available = False
+
+            def __call__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("apex is not available in this CPU-only config audit environment")
+
+        multi_tensor_apply_stub.multi_tensor_applier = _MultiTensorApplier()
+        sys.modules["apex.multi_tensor_apply"] = multi_tensor_apply_stub
+    if "transformer_engine" not in sys.modules:
+        te_stub = types.ModuleType("transformer_engine")
+        te_stub.__path__ = []
+        sys.modules["transformer_engine"] = te_stub
+    if "transformer_engine.pytorch" not in sys.modules:
+        import torch
+
+        te_pytorch_stub = types.ModuleType("transformer_engine.pytorch")
+        te_pytorch_stub.__path__ = []
+        te_pytorch_stub.RMSNorm = torch.nn.RMSNorm
+        sys.modules["transformer_engine.pytorch"] = te_pytorch_stub
+        sys.modules["transformer_engine"].pytorch = te_pytorch_stub
+    if "transformer_engine.pytorch.attention" not in sys.modules:
+        attention_stub = types.ModuleType("transformer_engine.pytorch.attention")
+
+        class _DotProductAttention:  # pragma: no cover - import-only stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError(
+                    "transformer_engine is not available in this CPU-only config audit environment"
+                )
+
+        def _apply_rotary_pos_emb(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - import-only stub
+            raise RuntimeError("transformer_engine is not available in this CPU-only config audit environment")
+
+        attention_stub.DotProductAttention = _DotProductAttention
+        attention_stub.apply_rotary_pos_emb = _apply_rotary_pos_emb
+        sys.modules["transformer_engine.pytorch.attention"] = attention_stub
+    if "transformer_engine.pytorch.distributed" not in sys.modules:
+        distributed_stub = types.ModuleType("transformer_engine.pytorch.distributed")
+        distributed_stub.get_all_rng_states = lambda: []
+        distributed_stub.graph_safe_rng_available = lambda: False
+        sys.modules["transformer_engine.pytorch.distributed"] = distributed_stub
+    if "transformer_engine.pytorch.module" not in sys.modules:
+        te_module_stub = types.ModuleType("transformer_engine.pytorch.module")
+        te_module_stub.__path__ = []
+        sys.modules["transformer_engine.pytorch.module"] = te_module_stub
+    if "transformer_engine.pytorch.module.base" not in sys.modules:
+        import torch
+
+        te_base_stub = types.ModuleType("transformer_engine.pytorch.module.base")
+        te_base_stub.TransformerEngineBaseModule = torch.nn.Module
+        sys.modules["transformer_engine.pytorch.module.base"] = te_base_stub
+    if "torchvision" not in sys.modules:
+        torchvision_stub = types.ModuleType("torchvision")
+        torchvision_stub.__path__ = []
+        sys.modules["torchvision"] = torchvision_stub
+    if "torchvision.transforms" not in sys.modules:
+        transforms_stub = types.ModuleType("torchvision.transforms")
+        transforms_stub.__path__ = []
+
+        class _InterpolationMode:  # pragma: no cover - import-only stub
+            NEAREST = "nearest"
+
+        class _Resize:  # pragma: no cover - import-only stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("torchvision is not available in this CPU-only config audit environment")
+
+        class _GaussianBlur:  # pragma: no cover - import-only stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("torchvision is not available in this CPU-only config audit environment")
+
+        transforms_stub.InterpolationMode = _InterpolationMode
+        transforms_stub.Resize = _Resize
+        transforms_stub.GaussianBlur = _GaussianBlur
+        sys.modules["torchvision.transforms"] = transforms_stub
+        sys.modules["torchvision"].transforms = transforms_stub
+    if "torchvision.transforms.functional" not in sys.modules:
+        functional_stub = types.ModuleType("torchvision.transforms.functional")
+
+        def _unavailable(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - import-only stub
+            raise RuntimeError("torchvision is not available in this CPU-only config audit environment")
+
+        functional_stub.resize = _unavailable
+        functional_stub.center_crop = _unavailable
+        functional_stub.to_tensor = _unavailable
+        sys.modules["torchvision.transforms.functional"] = functional_stub
+        sys.modules["torchvision.transforms"].functional = functional_stub
+    if "safetensors" not in sys.modules:
+        safetensors_stub = types.ModuleType("safetensors")
+        safetensors_stub.__path__ = []
+        sys.modules["safetensors"] = safetensors_stub
+    if "safetensors.torch" not in sys.modules:
+        safetensors_torch_stub = types.ModuleType("safetensors.torch")
+
+        def _safetensors_unavailable(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - import-only stub
+            raise RuntimeError("safetensors is not available in this CPU-only config audit environment")
+
+        safetensors_torch_stub.load = _safetensors_unavailable
+        safetensors_torch_stub.load_file = _safetensors_unavailable
+        safetensors_torch_stub.save_file = _safetensors_unavailable
+        sys.modules["safetensors.torch"] = safetensors_torch_stub
+    if "diffusers" not in sys.modules:
+        diffusers_stub = types.ModuleType("diffusers")
+        diffusers_stub.__path__ = []
+        sys.modules["diffusers"] = diffusers_stub
+    if "diffusers.configuration_utils" not in sys.modules:
+        configuration_utils_stub = types.ModuleType("diffusers.configuration_utils")
+        configuration_utils_stub.register_to_config = lambda fn: fn
+        sys.modules["diffusers.configuration_utils"] = configuration_utils_stub
+    if "diffusers.schedulers" not in sys.modules:
+        schedulers_stub = types.ModuleType("diffusers.schedulers")
+
+        class _KDPM2DiscreteScheduler:  # pragma: no cover - import-only stub
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                self.config = types.SimpleNamespace(**kwargs)
+
+        schedulers_stub.KDPM2DiscreteScheduler = _KDPM2DiscreteScheduler
+        sys.modules["diffusers.schedulers"] = schedulers_stub
+
+
+def _get(obj: Any, name: str, default: Any = None) -> Any:
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _jsonable(value: Any) -> Any:
+    # NOTE: to_container / asdict can leave nested LazyDict callables (e.g. a
+    # data_config ``_target_`` function) in the result, which json.dumps cannot
+    # serialize. Recurse through the results and stringify callables so JSON
+    # mode does not crash and markdown/JSON agree.
+    if isinstance(value, (DictConfig, ListConfig)):
+        return _jsonable(OmegaConf.to_container(value, resolve=True))
+    if attrs.has(value.__class__):
+        return _jsonable(attrs.asdict(value))
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if callable(value):
+        module = getattr(value, "__module__", None)
+        qualname = getattr(value, "__qualname__", None) or repr(value)
+        return f"<callable {module + '.' if module else ''}{qualname}>"
+    if hasattr(value, "__dict__"):
+        return {
+            str(k): _jsonable(v)
+            for k, v in vars(value).items()
+            if not k.startswith("_") and isinstance(v, (str, int, float, bool, dict, list, tuple))
+        }
+    return str(value)
+
+
+def _fields(prefix: str, obj: Any) -> OrderedDict[str, Any]:
+    data = _jsonable(obj)
+    fields: OrderedDict[str, Any] = OrderedDict()
+    if isinstance(data, dict):
+        for key in sorted(data):
+            fields[f"{prefix}.{key}"] = data[key]
+    else:
+        fields[prefix] = data
+    return fields
+
+
+def _describe_config_ref(obj: Any) -> Any:
+    """Full resolved mapping for a config reference (callables stringified by
+    ``_jsonable``).
+
+    A cherry-picked key subset used to hide the split-identifying kwargs (dataset
+    dir/name/split) that live under whatever keys a given data_config actually
+    uses, so the parity sheet could not tell goal_half from goal_tenth. Dumping
+    the whole thing is strictly more informative and no longer crashes JSON mode.
+    """
+    if obj is None:
+        return None
+    return _jsonable(obj)
+
+
+def resolve_experiment(experiment: str) -> OrderedDict[str, Any]:
+    _install_config_import_stubs()
+    config_log = io.StringIO()
+    with contextlib.redirect_stdout(config_log):
+        from cosmos_predict2.configs.config import make_config
+        from imaginaire.utils.config_helper import override
+
+        config = override(make_config(), ["--", f"experiment={experiment}"])
+    if config_log.getvalue():
+        print(config_log.getvalue(), file=sys.stderr, end="")
+    model_config = config.model.config
+    pipe_config = model_config.pipe_config
+    net_config = pipe_config.net
+
+    row: OrderedDict[str, Any] = OrderedDict()
+    row["experiment"] = experiment
+    row["job.group"] = _get(config.job, "group")
+    row["job.name"] = _get(config.job, "name")
+    row.update(_fields("action_source_prior", pipe_config.action_source_prior))
+    row.update(_fields("action_conditioning", pipe_config.action_conditioning))
+    row["ema.enabled"] = _get(pipe_config.ema, "enabled")
+    row["ema.rate"] = _get(pipe_config.ema, "rate")
+    row["scheduler.alpha"] = _get(pipe_config.scheduler, "alpha")
+    row["scheduler.beta"] = _get(pipe_config.scheduler, "beta")
+    row["scheduler.num_denoising_steps"] = _get(pipe_config.scheduler, "num_denoising_steps")
+    row["net.max_horizon"] = _get(net_config, "max_horizon")
+    row["net.out_channels"] = _get(net_config, "out_channels")
+    row["net.crossattn_emb_channels"] = _get(net_config, "crossattn_emb_channels")
+    row["pipe_config.xattn_layer_idx"] = _get(pipe_config, "xattn_layer_idx")
+    row["model.config.offline_video_embedding_dir"] = _get(model_config, "offline_video_embedding_dir")
+    row["model.config.offline_video_embedding_required"] = _get(model_config, "offline_video_embedding_required")
+    row["model.config.offline_video_latent_dir"] = _get(model_config, "offline_video_latent_dir")
+    row["model.config.offline_video_latent_required"] = _get(model_config, "offline_video_latent_required")
+    row["model.config.sampled_mse_probe_interval"] = _get(model_config, "sampled_mse_probe_interval")
+    row["data_config"] = _describe_config_ref(config.data_config)
+    row["video_dataset_train"] = _describe_config_ref(config.video_dataset_train)
+    row["video_dataset_val"] = _describe_config_ref(config.video_dataset_val)
+    return row
+
+
+def _filtered_rows(rows: OrderedDict[str, OrderedDict[str, Any]], diff_only: bool) -> list[str]:
+    fields = list(next(iter(rows.values())).keys())
+    if not diff_only or len(rows) <= 1:
+        return fields
+    first = next(iter(rows.values()))
+    keep = []
+    for field in fields:
+        first_val = first[field]
+        if any(row[field] != first_val for row in rows.values()):
+            keep.append(field)
+    return keep
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, default=str)
+    return "" if value is None else str(value)
+
+
+def print_markdown(rows: OrderedDict[str, OrderedDict[str, Any]], diff_only: bool) -> None:
+    fields = _filtered_rows(rows, diff_only)
+    experiments = list(rows)
+    print("| item | " + " | ".join(experiments) + " |")
+    print("|---|" + "|".join("---" for _ in experiments) + "|")
+    for field in fields:
+        values = [_format_value(rows[experiment][field]).replace("|", "\\|") for experiment in experiments]
+        print(f"| {field} | " + " | ".join(values) + " |")
+
+
+def print_json(rows: OrderedDict[str, OrderedDict[str, Any]], diff_only: bool) -> None:
+    fields = _filtered_rows(rows, diff_only)
+    filtered = OrderedDict(
+        (experiment, OrderedDict((field, row[field]) for field in fields)) for experiment, row in rows.items()
+    )
+    print(json.dumps(filtered, indent=2, sort_keys=False, default=str))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experiments", nargs="+", default=DEFAULT_EXPERIMENTS)
+    parser.add_argument("--diff", action="store_true", help="Only print fields that differ from the first experiment")
+    parser.add_argument("--markdown", action="store_true", help="Emit a markdown table instead of JSON")
+    args = parser.parse_args()
+
+    rows = OrderedDict((experiment, resolve_experiment(experiment)) for experiment in args.experiments)
+    if args.markdown:
+        print_markdown(rows, args.diff)
+    else:
+        print_json(rows, args.diff)
+
+
+if __name__ == "__main__":
+    main()

--- a/model/scripts/vlsp_probe_prior.py
+++ b/model/scripts/vlsp_probe_prior.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Offline VLSP diagnostics on a trained checkpoint (CPU is fine, no sim needed).
+
+Run-1 post-mortem tool (see VLSP_RUN1_ANALYSIS.md). Answers, in minutes:
+
+  D1  Are `source_prior.*` weights present in the checkpoint at all?
+      (If not, eval silently used a randomly initialized prior.)
+  D2  Did the prior degenerate?
+      - variance collapse: fraction of logstd at the clamp floor;
+      - input independence: does `mu` change when the video latent changes?
+
+Usage:
+    # checkpoint key audit + synthetic-input probe (always works, CPU):
+    python -m scripts.vlsp_probe_prior --ckpt /path/to/model/iter_000024000.pt
+
+    # additionally probe with REAL video latents (recommended), where
+    # latents.pt is a tensor [K, N, D] or a list of [N, D]/[B, N, D] tensors
+    # from K different tasks (dump crossattn_emb in eval or a data loop):
+    python -m scripts.vlsp_probe_prior --ckpt ... --latents latents.pt
+
+Interpretation:
+    logstd_floor_frac ~ 1.0            -> variance collapse CONFIRMED
+    cross-input mu diff ~ 0            -> prior IGNORES its input (trained-time
+                                          degeneration; eval OOD is moot)
+    cross-input mu diff clearly > 0    -> prior is input-sensitive; suspect the
+                                          eval-side inputs (generated video /
+                                          stop-step sigma) or eval loading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from typing import Optional
+
+import torch
+
+SP_PREFIX = "source_prior."
+SP_NET_PREFIX = "source_prior.net."
+
+
+def load_flat_state_dict(path: str) -> dict[str, torch.Tensor]:
+    payload = torch.load(path, map_location="cpu", weights_only=False)
+    # Model checkpoints are flat dicts (net./net_ema./source_prior.*); some
+    # tooling wraps them under "model".
+    if isinstance(payload, dict) and "model" in payload and isinstance(payload["model"], dict):
+        payload = payload["model"]
+    if not isinstance(payload, dict):
+        raise ValueError(f"Unrecognized checkpoint structure in {path}")
+    return {k: v for k, v in payload.items() if isinstance(v, torch.Tensor)}
+
+
+def audit_keys(sd: dict[str, torch.Tensor]) -> dict[str, int]:
+    counts = {
+        "net.*": sum(k.startswith("net.") for k in sd),
+        "net_ema.*": sum(k.startswith("net_ema.") for k in sd),
+        "source_prior.*": sum(k.startswith(SP_PREFIX) for k in sd),
+        "source_prior_ema.*": sum(k.startswith("source_prior_ema.") for k in sd),
+    }
+    print("== D1: checkpoint key audit ==")
+    for name, n in counts.items():
+        print(f"  {name:<22} {n}")
+    if counts["source_prior.*"] == 0:
+        print(
+            "  !! NO source_prior.* keys -> eval built a RANDOMLY INITIALIZED prior\n"
+            "     (mu==0 exactly at init) -> constant near-mean actions. Fix the\n"
+            "     checkpoint/save path before blaming the training run."
+        )
+    else:
+        sample = [k for k in sd if k.startswith(SP_PREFIX)][:4]
+        print(f"  sample keys: {sample}")
+    return counts
+
+
+def infer_arch(sp: dict[str, torch.Tensor]) -> dict:
+    """Infer VideoLatentSourcePrior hyperparameters from checkpoint shapes."""
+    arch: dict = {}
+    arch["video_emb_dim"] = sp["ctx_norm.weight"].shape[0]
+    arch["hidden_dim"] = sp["mu_head.weight"].shape[1]
+    arch["action_dim"] = sp["mu_head.weight"].shape[0]
+    arch["max_horizon"] = sp["horizon_queries"].shape[1]
+    if "pool.latents" in sp:
+        arch["pool_type"] = "perceiver"
+        arch["num_perceiver_latents"] = sp["pool.latents"].shape[1]
+    elif "pool.query" in sp:
+        arch["pool_type"] = "attention"
+    else:
+        arch["pool_type"] = "mean"
+    arch["use_state"] = any(k.startswith("state_proj.") for k in sp)
+    if arch["use_state"]:
+        arch["state_dim"] = sp["state_proj.weight"].shape[1]
+    arch["use_context_timestep"] = any(k.startswith("time_proj.") for k in sp)
+    arch["use_language"] = any(k.startswith("lang_proj.") for k in sp)
+    trunk_linears = {
+        int(m.group(1))
+        for k, v in sp.items()
+        if (m := re.match(r"trunk\.net\.(\d+)\.weight", k)) and v.dim() == 2  # Linear only (LayerNorm is 1-D)
+    }
+    arch["mlp_depth"] = max(1, len(trunk_linears))
+    print("== inferred prior architecture ==")
+    for k, v in sorted(arch.items()):
+        print(f"  {k:<22} {v}")
+    return arch
+
+
+def build_prior_net(arch: dict, num_attention_heads: int):
+    from types import SimpleNamespace
+
+    from cosmos_predict2.models.action_source_prior import VideoLatentSourcePrior
+
+    cfg = SimpleNamespace(
+        enabled=True,
+        mode="video_prior_sample",
+        pool_type=arch["pool_type"],
+        hidden_dim=arch["hidden_dim"],
+        num_perceiver_latents=arch.get("num_perceiver_latents", 8),
+        num_attention_heads=num_attention_heads,
+        mlp_depth=max(1, arch["mlp_depth"]),
+        logstd_min=-5.0,
+        logstd_max=1.0,
+        init_logstd=-1.0,
+        residual_scale=1.0,
+        blend_alpha=1.0,
+        source_dropout_prob=0.0,
+        dropout_granularity="sample",
+        sampling_temperature=1.0,
+        detach_video_latents=True,
+        use_state=arch["use_state"],
+        use_context_timestep=arch["use_context_timestep"],
+        use_language=arch["use_language"],
+        kl_weight=0.0,
+        mean_l2_weight=0.0,
+        std_reg_weight=0.0,
+        debug_noise_std=0.05,
+    )
+    net = VideoLatentSourcePrior(
+        cfg,
+        action_dim=arch["action_dim"],
+        video_emb_dim=arch["video_emb_dim"],
+        state_dim=arch.get("state_dim", arch["action_dim"]),
+        max_horizon=arch["max_horizon"],
+    )
+    return net
+
+
+@torch.no_grad()
+def probe(net, arch: dict, latents_groups: list[torch.Tensor], horizon: int, sigma: float) -> None:
+    """Feed K latent groups through the prior; report input sensitivity + collapse."""
+    net.eval()
+    mus, logstds = [], []
+    for group in latents_groups:
+        x = group.float()
+        if x.dim() == 2:  # [N, D] -> [1, N, D]
+            x = x.unsqueeze(0)
+        ctx = torch.full((x.shape[0], 1), float(sigma))
+        mu, logstd = net(x, None, ctx, horizon, None)
+        mus.append(mu.float())
+        logstds.append(logstd.float())
+
+    K = len(mus)
+    mu_stack = torch.stack([m.mean(dim=0) for m in mus])  # [K, HA, A] per-group mean
+    action_scale = mu_stack.abs().mean().clamp_min(1e-6)
+
+    pair_diffs = []
+    for i in range(K):
+        for j in range(i + 1, K):
+            pair_diffs.append((mu_stack[i] - mu_stack[j]).abs().mean())
+    cross_input_diff = torch.stack(pair_diffs).mean().item() if pair_diffs else float("nan")
+
+    logstd_all = torch.cat([ls.reshape(-1) for ls in logstds])
+    floor_frac = (logstd_all <= -5.0 + 0.05).float().mean().item()
+
+    print("== D2: prior degeneration probe ==")
+    print(f"  groups (K)                    : {K}")
+    print(f"  |mu| scale                    : {action_scale.item():.4f}")
+    print(f"  cross-input mu |diff| (mean)  : {cross_input_diff:.6f}")
+    print(f"  cross-input / |mu| ratio      : {cross_input_diff / action_scale.item():.4f}")
+    print(f"  logstd mean                   : {logstd_all.mean().item():.4f}")
+    print(f"  logstd floor fraction (<=-4.95): {floor_frac:.4f}")
+
+    print("== verdicts ==")
+    if floor_frac > 0.9:
+        print("  [X] VARIANCE COLLAPSE confirmed (logstd pinned at the clamp floor).")
+    elif floor_frac > 0.3:
+        print("  [!] Partial variance collapse (a large share of logstd at the floor).")
+    else:
+        print("  [ok] No variance collapse in logstd.")
+    ratio = cross_input_diff / action_scale.item()
+    if ratio < 0.02:
+        print(
+            "  [X] INPUT-INDEPENDENT PRIOR: mu is (near-)identical across different\n"
+            "      video latents -> the prior degenerated during TRAINING; eval-side\n"
+            "      OOD is not the primary cause."
+        )
+    elif ratio < 0.15:
+        print("  [!] Weak input sensitivity — inspect with real latents before concluding.")
+    else:
+        print(
+            "  [ok] mu clearly varies with the input. If eval still produces a fixed\n"
+            "      action, suspect the EVAL inputs (generated-video hidden states /\n"
+            "      stop-step sigma) or eval-side loading, not the prior itself."
+        )
+
+
+def load_latent_groups(path: Optional[str], arch: dict, num_synthetic: int, tokens: int) -> list[torch.Tensor]:
+    if path:
+        obj = torch.load(path, map_location="cpu", weights_only=False)
+        if isinstance(obj, torch.Tensor):
+            groups = [obj[i] for i in range(obj.shape[0])]
+        elif isinstance(obj, (list, tuple)):
+            groups = [torch.as_tensor(t) for t in obj]
+        else:
+            raise ValueError("--latents must be a tensor [K,N,D] or a list of tensors")
+        print(f"loaded {len(groups)} REAL latent groups from {path}")
+        return groups
+    g = torch.Generator().manual_seed(0)
+    groups = [torch.randn(1, tokens, arch["video_emb_dim"], generator=g) for _ in range(num_synthetic)]
+    print(
+        f"using {num_synthetic} SYNTHETIC latent groups (no --latents given). "
+        "Constant mu across these is conclusive for input-independence; variation is not\n"
+        "conclusive for eval health — re-run with real latents for the full answer."
+    )
+    return groups
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ckpt", required=True, help="model checkpoint (.pt with net./source_prior.* keys)")
+    ap.add_argument("--latents", default=None, help="optional .pt with real crossattn latents [K,N,D]")
+    ap.add_argument("--horizon", type=int, default=None, help="action horizon HA (default: max_horizon-1... uses 15 if unknown)")
+    ap.add_argument("--sigma", type=float, default=8.0, help="context timestep (video sigma) fed to the prior")
+    ap.add_argument("--num-synthetic", type=int, default=6)
+    ap.add_argument("--tokens", type=int, default=1225, help="synthetic token count (7x… matches T*H*W)")
+    ap.add_argument("--heads", type=int, default=8, help="attention heads (attention/perceiver pools; not inferable)")
+    args = ap.parse_args()
+
+    sd = load_flat_state_dict(args.ckpt)
+    counts = audit_keys(sd)
+    if counts["source_prior.*"] == 0:
+        return
+
+    sp_net = {k[len(SP_NET_PREFIX) :]: v for k, v in sd.items() if k.startswith(SP_NET_PREFIX)}
+    if not sp_net:
+        print("!! source_prior.* keys exist but no source_prior.net.* — disabled/gaussian prior; nothing to probe.")
+        return
+    arch = infer_arch(sp_net)
+
+    net = build_prior_net(arch, num_attention_heads=args.heads)
+    missing, unexpected = net.load_state_dict(sp_net, strict=False)
+    print(f"loaded prior net: missing={len(missing)} unexpected={len(unexpected)}")
+    if missing:
+        print(f"  missing (first 5): {missing[:5]}")
+
+    horizon = args.horizon if args.horizon is not None else min(15, arch["max_horizon"])
+    groups = load_latent_groups(args.latents, arch, args.num_synthetic, args.tokens)
+    probe(net, arch, groups, horizon=horizon, sigma=args.sigma)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/continue_goal_after_source_condition.sh
+++ b/scripts/continue_goal_after_source_condition.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+MODEL_DIR="${REPO_DIR}/model"
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+LOG_DIR="${RUN_ROOT}/logs"
+STATE_FILE="${RUN_ROOT}/goal_continuation_state.tsv"
+
+GPUS=${GPUS:-0,1,2,3}
+NPROC_PER_NODE=${NPROC_PER_NODE:-4}
+MASTER_PORT=${MASTER_PORT:-29661}
+MAX_ITER=${MAX_ITER:-50000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000000}
+POLL_SECONDS=${POLL_SECONDS:-300}
+
+SOURCE_GROUP=${SOURCE_GROUP:-vlsp_source_condition}
+SOURCE_NAME=${SOURCE_NAME:-vlsp_source_condition_goal_20260629_183112}
+SOURCE_CKPT_DIR="${MODEL_DIR}/checkpoints/vam/${SOURCE_GROUP}/${SOURCE_NAME}/checkpoints"
+SOURCE_LATEST="${SOURCE_CKPT_DIR}/latest_checkpoint.txt"
+
+GOAL_DATA_CONFIG=${GOAL_DATA_CONFIG:-libero_goal_full_no_rgb}
+GOAL_EXP="w2a_${GOAL_DATA_CONFIG}_v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused_lr1.000e-04_layer20_bsz128"
+GOAL_VIDEO_LATENT_NAME="${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_tokenizer_latents"
+SHM_GOAL_VIDEO_LATENT_DIR="/dev/shm/mimic_video_latents/${GOAL_VIDEO_LATENT_NAME}"
+DEFAULT_GOAL_VIDEO_LATENT_DIR="${REPO_DIR}/data/libero_video_latents/${GOAL_VIDEO_LATENT_NAME}"
+if [[ -n "${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR:-}" ]]; then
+  GOAL_VIDEO_LATENT_DIR="${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR}"
+elif [[ -f "${SHM_GOAL_VIDEO_LATENT_DIR}/metadata.json" && -f "${SHM_GOAL_VIDEO_LATENT_DIR}/video_latent.fp16.memmap" ]]; then
+  GOAL_VIDEO_LATENT_DIR="${SHM_GOAL_VIDEO_LATENT_DIR}"
+else
+  GOAL_VIDEO_LATENT_DIR="${DEFAULT_GOAL_VIDEO_LATENT_DIR}"
+fi
+
+mkdir -p "${LOG_DIR}"
+
+ts() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+log() {
+  echo "[$(ts)] $*"
+}
+
+record_state() {
+  local status=$1
+  local variant=$2
+  local job_name=$3
+  local log_path=$4
+  printf '%s\t%s\t%s\t%s\t%s\n' "$(ts)" "${status}" "${variant}" "${job_name}" "${log_path}" >> "${STATE_FILE}"
+}
+
+latest_iter() {
+  if [[ ! -f "${SOURCE_LATEST}" ]]; then
+    echo 0
+    return
+  fi
+  local latest
+  latest=$(tr -d '[:space:]' < "${SOURCE_LATEST}")
+  if [[ "${latest}" =~ iter_0*([0-9]+)\.pt ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo 0
+  fi
+}
+
+source_running() {
+  pgrep -f "job.group=${SOURCE_GROUP}.*job.name=${SOURCE_NAME}" >/dev/null 2>&1 \
+    || pgrep -f "job.name=${SOURCE_NAME}.*job.group=${SOURCE_GROUP}" >/dev/null 2>&1
+}
+
+require_file() {
+  [[ -f "$1" ]] || { log "ERROR missing file: $1" >&2; exit 1; }
+}
+
+preflight() {
+  [[ -x "${PYTHON}" ]] || { log "ERROR Python is not executable: ${PYTHON}" >&2; exit 1; }
+  require_file "${REPO_DIR}/checkpoints/video_backbone/v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused.pt"
+  require_file "${GOAL_VIDEO_LATENT_DIR}/metadata.json"
+  require_file "${GOAL_VIDEO_LATENT_DIR}/video_latent.fp16.memmap"
+}
+
+wait_for_source_condition() {
+  log "Waiting for ${SOURCE_GROUP}/${SOURCE_NAME} to reach iter ${MAX_ITER}."
+  while true; do
+    local iter
+    iter=$(latest_iter)
+    if (( iter >= MAX_ITER )); then
+      log "source+cond latest checkpoint is iter ${iter}. Waiting for source process to exit before continuing."
+      while source_running; do
+        sleep 60
+      done
+      log "source+cond completed. Continuing goal queue."
+      return 0
+    fi
+    if ! source_running; then
+      log "ERROR source+cond is not running and latest checkpoint is only iter ${iter}; refusing to launch downstream experiments." >&2
+      return 1
+    fi
+    log "source+cond latest checkpoint iter ${iter}; still running. Sleeping ${POLL_SECONDS}s."
+    sleep "${POLL_SECONDS}"
+  done
+}
+
+run_variant() {
+  local variant=$1
+  local source_enabled=$2
+  local source_mode=$3
+  local conditioning_mode=$4
+  local master_port=$5
+
+  local stamp
+  stamp=$(date -u +%Y%m%d_%H%M%S)
+  local job_name="${variant}_goal_${stamp}"
+  local log_path="${LOG_DIR}/${job_name}.log"
+
+  record_state "START" "${variant}" "${job_name}" "${log_path}"
+  log "START ${job_name}" | tee -a "${log_path}"
+  log "log=${log_path}" | tee -a "${log_path}"
+  log "experiment=${GOAL_EXP}" | tee -a "${log_path}"
+  log "offline_video_latent_dir=${GOAL_VIDEO_LATENT_DIR}" | tee -a "${log_path}"
+
+  set +e
+  (
+    cd "${MODEL_DIR}"
+    export CUDA_VISIBLE_DEVICES="${GPUS}"
+    export PYTHONPATH="${MODEL_DIR}:${PYTHONPATH:-}"
+    export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-7200}
+    export TORCH_NCCL_ASYNC_ERROR_HANDLING=${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}
+    export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+    export NVTE_FUSED_ATTN=${NVTE_FUSED_ATTN:-0}
+    export DEBUG_STEP_TIMING=0
+    export DEBUG_W2A_TIMING=0
+
+    "${PYTHON}" -m torch.distributed.run \
+      --nproc_per_node="${NPROC_PER_NODE}" \
+      --master_port="${master_port}" \
+      -m scripts.train \
+      --config=cosmos_predict2/configs/config.py -- \
+      "experiment=${GOAL_EXP}" \
+      "job.group=${variant}" \
+      "job.name=${job_name}" \
+      "trainer.max_iter=${MAX_ITER}" \
+      "trainer.logging_iter=${LOGGING_ITER}" \
+      "trainer.validation_iter=${VALIDATION_ITER}" \
+      "trainer.grad_accum_iter=1" \
+      "checkpoint.save_iter=${SAVE_ITER}" \
+      "dataloader_train.batch_size.global_bsz=32" \
+      "dataloader_train.num_workers=1" \
+      "dataloader_train.prefetch_factor=1" \
+      "dataloader_train.persistent_workers=false" \
+      "dataloader_train.pin_memory=false" \
+      "dataloader_train.in_order=true" \
+      "model.config.offline_video_embedding_dir=" \
+      "model.config.offline_video_embedding_required=false" \
+      "model.config.offline_video_latent_dir=${GOAL_VIDEO_LATENT_DIR}" \
+      "model.config.offline_video_latent_required=true" \
+      "model.config.pipe_config.action_source_prior.enabled=${source_enabled}" \
+      "model.config.pipe_config.action_source_prior.mode=${source_mode}" \
+      "model.config.pipe_config.action_conditioning.mode=${conditioning_mode}"
+  ) 2>&1 | tee -a "${log_path}"
+  local status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "${status}" -ne 0 ]]; then
+    record_state "FAIL:${status}" "${variant}" "${job_name}" "${log_path}"
+    log "FAIL ${job_name} status=${status}" | tee -a "${log_path}"
+    return "${status}"
+  fi
+
+  record_state "DONE" "${variant}" "${job_name}" "${log_path}"
+  log "DONE ${job_name}" | tee -a "${log_path}"
+}
+
+main() {
+  preflight
+  wait_for_source_condition
+  run_variant "vlsp_source_only" true video_prior_sample zero_video "${MASTER_PORT}"
+  run_variant "baseline_gaussian" false gaussian normal "$((MASTER_PORT + 1))"
+  log "Goal source-only and baseline continuation completed."
+}
+
+main "$@"

--- a/scripts/download_libero_raw_hdf5.sh
+++ b/scripts/download_libero_raw_hdf5.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT_DIR=${1:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video/data/libero_raw}
+BASE_URL=${LIBERO_HF_BASE_URL:-https://hf-mirror.com/datasets/yifengzhu-hf/LIBERO-datasets/resolve/main}
+
+mkdir -p "${OUT_DIR}"
+
+download_one() {
+  local rel=$1
+  local expected_size=$2
+  local dst="${OUT_DIR}/${rel}"
+  mkdir -p "$(dirname "${dst}")"
+
+  if [[ -f "${dst}" ]]; then
+    local got
+    got=$(stat -c '%s' "${dst}")
+    if [[ "${got}" == "${expected_size}" ]]; then
+      echo "skip complete: ${rel} (${got} bytes)"
+      return 0
+    fi
+    echo "resume: ${rel} (${got}/${expected_size} bytes)"
+  else
+    echo "download: ${rel} (${expected_size} bytes)"
+  fi
+
+  local attempt=1
+  until wget -c \
+      --tries=20 \
+      --timeout=30 \
+      --read-timeout=120 \
+      --retry-connrefused \
+      --waitretry=5 \
+      --progress=dot:giga \
+      -O "${dst}" \
+      "${BASE_URL}/${rel}"; do
+    if [[ "${attempt}" -ge "${LIBERO_WGET_OUTER_TRIES:-8}" ]]; then
+      echo "ERROR: failed after ${attempt} attempts: ${rel}" >&2
+      exit 1
+    fi
+    attempt=$((attempt + 1))
+    echo "retry ${attempt}/${LIBERO_WGET_OUTER_TRIES:-8}: ${rel}"
+    sleep "${LIBERO_WGET_OUTER_SLEEP:-10}"
+  done
+
+  local final_size
+  final_size=$(stat -c '%s' "${dst}")
+  if [[ "${final_size}" != "${expected_size}" ]]; then
+    echo "ERROR: size mismatch for ${rel}: got ${final_size}, expected ${expected_size}" >&2
+    exit 1
+  fi
+}
+
+download_one "libero_goal/open_the_middle_drawer_of_the_cabinet_demo.hdf5" 702223367
+download_one "libero_goal/open_the_top_drawer_and_put_the_bowl_inside_demo.hdf5" 1017886342
+download_one "libero_goal/push_the_plate_to_the_front_of_the_stove_demo.hdf5" 762855139
+download_one "libero_goal/put_the_bowl_on_the_plate_demo.hdf5" 468246288
+download_one "libero_goal/put_the_bowl_on_the_stove_demo.hdf5" 509123820
+download_one "libero_goal/put_the_bowl_on_top_of_the_cabinet_demo.hdf5" 510414285
+download_one "libero_goal/put_the_cream_cheese_in_the_bowl_demo.hdf5" 535715512
+download_one "libero_goal/put_the_wine_bottle_on_the_rack_demo.hdf5" 878958730
+download_one "libero_goal/put_the_wine_bottle_on_top_of_the_cabinet_demo.hdf5" 540179470
+download_one "libero_goal/turn_on_the_stove_demo.hdf5" 447509922
+
+download_one "libero_spatial/pick_up_the_black_bowl_between_the_plate_and_the_ramekin_and_place_it_on_the_plate_demo.hdf5" 508779600
+download_one "libero_spatial/pick_up_the_black_bowl_from_table_center_and_place_it_on_the_plate_demo.hdf5" 589630943
+download_one "libero_spatial/pick_up_the_black_bowl_in_the_top_drawer_of_the_wooden_cabinet_and_place_it_on_the_plate_demo.hdf5" 748271833
+download_one "libero_spatial/pick_up_the_black_bowl_next_to_the_cookie_box_and_place_it_on_the_plate_demo.hdf5" 632345992
+download_one "libero_spatial/pick_up_the_black_bowl_next_to_the_plate_and_place_it_on_the_plate_demo.hdf5" 597677074
+download_one "libero_spatial/pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_demo.hdf5" 671583385
+download_one "libero_spatial/pick_up_the_black_bowl_on_the_cookie_box_and_place_it_on_the_plate_demo.hdf5" 507189857
+download_one "libero_spatial/pick_up_the_black_bowl_on_the_ramekin_and_place_it_on_the_plate_demo.hdf5" 581087722
+download_one "libero_spatial/pick_up_the_black_bowl_on_the_stove_and_place_it_on_the_plate_demo.hdf5" 711715594
+download_one "libero_spatial/pick_up_the_black_bowl_on_the_wooden_cabinet_and_place_it_on_the_plate_demo.hdf5" 688768764
+
+download_one "libero_object/pick_up_the_alphabet_soup_and_place_it_in_the_basket_demo.hdf5" 780145352
+download_one "libero_object/pick_up_the_bbq_sauce_and_place_it_in_the_basket_demo.hdf5" 734212272
+download_one "libero_object/pick_up_the_butter_and_place_it_in_the_basket_demo.hdf5" 785532626
+download_one "libero_object/pick_up_the_chocolate_pudding_and_place_it_in_the_basket_demo.hdf5" 797322420
+download_one "libero_object/pick_up_the_cream_cheese_and_place_it_in_the_basket_demo.hdf5" 718919781
+download_one "libero_object/pick_up_the_ketchup_and_place_it_in_the_basket_demo.hdf5" 804674488
+download_one "libero_object/pick_up_the_milk_and_place_it_in_the_basket_demo.hdf5" 727315202
+download_one "libero_object/pick_up_the_orange_juice_and_place_it_in_the_basket_demo.hdf5" 696180446
+download_one "libero_object/pick_up_the_salad_dressing_and_place_it_in_the_basket_demo.hdf5" 664188039
+download_one "libero_object/pick_up_the_tomato_sauce_and_place_it_in_the_basket_demo.hdf5" 735593408

--- a/scripts/mimic_libero_train_status.sh
+++ b/scripts/mimic_libero_train_status.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+STATE_FILE="${RUN_ROOT}/queue_state.tsv"
+LOG_DIR="${RUN_ROOT}/logs"
+
+echo "== processes =="
+ps -ef | grep -E 'scripts.train|torch.distributed.run|train_libero_action_queue' | grep -v grep || true
+
+echo
+echo "== gpu =="
+nvidia-smi --query-gpu=index,memory.used,memory.total,utilization.gpu --format=csv,noheader,nounits || true
+
+echo
+echo "== queue state =="
+if [[ -f "${STATE_FILE}" ]]; then
+  tail -n 20 "${STATE_FILE}"
+else
+  echo "no state file: ${STATE_FILE}"
+fi
+
+echo
+echo "== latest log =="
+latest_log=$(find "${LOG_DIR}" -type f -name '*.log' -printf '%T@ %p\n' 2>/dev/null | sort -n | tail -n 1 | cut -d' ' -f2- || true)
+if [[ -n "${latest_log}" ]]; then
+  echo "${latest_log}"
+  tail -n 80 "${latest_log}"
+else
+  echo "no logs under ${LOG_DIR}"
+fi

--- a/scripts/monitor_goal_source_to_source_only.sh
+++ b/scripts/monitor_goal_source_to_source_only.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+MODEL_DIR="${REPO_DIR}/model"
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+LOG_DIR="${RUN_ROOT}/logs"
+MONITOR_LOG=${MONITOR_LOG:-"${LOG_DIR}/goal_source_to_source_only_monitor_$(date -u +%Y%m%d_%H%M%S).log"}
+
+SOURCE_GROUP=${SOURCE_GROUP:-vlsp_source_condition}
+SOURCE_NAME=${SOURCE_NAME:-vlsp_source_condition_goal_20260629_183112}
+SOURCE_LOG=${SOURCE_LOG:-"${LOG_DIR}/main_source_condition_goal_resume32_shm_setsid_20260630_054249.log"}
+SOURCE_CKPT_DIR="${MODEL_DIR}/checkpoints/vam/${SOURCE_GROUP}/${SOURCE_NAME}/checkpoints"
+SOURCE_LATEST="${SOURCE_CKPT_DIR}/latest_checkpoint.txt"
+
+GPUS=${GPUS:-0,1,2,3}
+NPROC_PER_NODE=${NPROC_PER_NODE:-4}
+MASTER_PORT=${MASTER_PORT:-29661}
+MAX_ITER=${MAX_ITER:-50000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000000}
+NORMAL_SLEEP=${NORMAL_SLEEP:-3600}
+FINAL_SLEEP=${FINAL_SLEEP:-600}
+FINAL_WINDOW=${FINAL_WINDOW:-500}
+WATCHER_GRACE_SECONDS=${WATCHER_GRACE_SECONDS:-1800}
+
+GOAL_DATA_CONFIG=${GOAL_DATA_CONFIG:-libero_goal_full_no_rgb}
+GOAL_EXP="w2a_${GOAL_DATA_CONFIG}_v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused_lr1.000e-04_layer20_bsz128"
+GOAL_VIDEO_LATENT_NAME="${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_tokenizer_latents"
+SHM_GOAL_VIDEO_LATENT_DIR="/dev/shm/mimic_video_latents/${GOAL_VIDEO_LATENT_NAME}"
+DEFAULT_GOAL_VIDEO_LATENT_DIR="${REPO_DIR}/data/libero_video_latents/${GOAL_VIDEO_LATENT_NAME}"
+GOAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR:-}
+if [[ -z "${GOAL_VIDEO_LATENT_DIR}" ]]; then
+  if [[ -f "${SHM_GOAL_VIDEO_LATENT_DIR}/metadata.json" && -f "${SHM_GOAL_VIDEO_LATENT_DIR}/video_latent.fp16.memmap" ]]; then
+    GOAL_VIDEO_LATENT_DIR="${SHM_GOAL_VIDEO_LATENT_DIR}"
+  else
+    GOAL_VIDEO_LATENT_DIR="${DEFAULT_GOAL_VIDEO_LATENT_DIR}"
+  fi
+fi
+
+mkdir -p "${LOG_DIR}"
+
+ts() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+log() {
+  echo "[$(ts)] $*" | tee -a "${MONITOR_LOG}"
+}
+
+latest_checkpoint_iter() {
+  local latest
+  [[ -f "${SOURCE_LATEST}" ]] || { echo 0; return; }
+  latest=$(tr -d '[:space:]' < "${SOURCE_LATEST}")
+  if [[ "${latest}" =~ iter_0*([0-9]+)\.pt ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo 0
+  fi
+}
+
+latest_progress_step() {
+  [[ -f "$1" ]] || { echo 0; return; }
+  perl -0777 -ne 'while(/Training:.*?\|\s*(\d+)\/50000/g){$s=$1} END{print $s || 0}' "$1" 2>/dev/null || echo 0
+}
+
+latest_loss_line() {
+  [[ -f "$1" ]] || { echo "loss_step=0 loss=NA speed=NA"; return; }
+  perl -0777 -ne 'while(/(\d+)\s+:\s+iter_speed\s+([0-9.]+).*?Loss:\s*([0-9.]+)/g){$s=$1;$v=$2;$l=$3} END{if($s){print "loss_step=$s loss=$l speed=${v}s"}else{print "loss_step=0 loss=NA speed=NA"}}' "$1" 2>/dev/null \
+    || echo "loss_step=0 loss=NA speed=NA"
+}
+
+source_running() {
+  pgrep -f "job.group=${SOURCE_GROUP}.*job.name=${SOURCE_NAME}" >/dev/null 2>&1 \
+    || pgrep -f "job.name=${SOURCE_NAME}.*job.group=${SOURCE_GROUP}" >/dev/null 2>&1
+}
+
+continuation_watcher_running() {
+  pgrep -f "scripts/continue_goal_after_source_condition.sh|continue_goal_after_source_condition.sh" >/dev/null 2>&1
+}
+
+source_only_running() {
+  pgrep -f "job.group=vlsp_source_only.*goal" >/dev/null 2>&1
+}
+
+latest_source_only_log() {
+  local latest
+  latest=$(find "${LOG_DIR}" -maxdepth 1 -type f -name 'vlsp_source_only_goal_*.log' -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk 'NR==1{print $2}')
+  echo "${latest:-}"
+}
+
+source_only_entered_training() {
+  local log_path=$1
+  [[ -n "${log_path}" && -f "${log_path}" ]] || return 1
+  grep -qE 'Training:|Iteration [0-9]+: Hit counter|[0-9]+ : iter_speed' "${log_path}"
+}
+
+launch_source_only_fallback() {
+  local lock_dir="${RUN_ROOT}/source_only_launch.lock"
+  if ! mkdir "${lock_dir}" 2>/dev/null; then
+    log "source-only launch lock exists; not launching a duplicate."
+    return 0
+  fi
+
+  local stamp job_name log_path
+  stamp=$(date -u +%Y%m%d_%H%M%S)
+  job_name="vlsp_source_only_goal_${stamp}"
+  log_path="${LOG_DIR}/${job_name}.log"
+
+  log "Fallback launching source-only: ${job_name}"
+  log "Fallback source-only log: ${log_path}"
+  (
+    cd "${MODEL_DIR}"
+    export CUDA_VISIBLE_DEVICES="${GPUS}"
+    export PYTHONPATH="${MODEL_DIR}:${PYTHONPATH:-}"
+    export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-7200}
+    export TORCH_NCCL_ASYNC_ERROR_HANDLING=${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}
+    export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+    export NVTE_FUSED_ATTN=${NVTE_FUSED_ATTN:-0}
+    export DEBUG_STEP_TIMING=0
+    export DEBUG_W2A_TIMING=0
+
+    exec "${PYTHON}" -m torch.distributed.run \
+      --nproc_per_node="${NPROC_PER_NODE}" \
+      --master_port="${MASTER_PORT}" \
+      -m scripts.train \
+      --config=cosmos_predict2/configs/config.py -- \
+      "experiment=${GOAL_EXP}" \
+      "job.group=vlsp_source_only" \
+      "job.name=${job_name}" \
+      "trainer.max_iter=${MAX_ITER}" \
+      "trainer.logging_iter=${LOGGING_ITER}" \
+      "trainer.validation_iter=${VALIDATION_ITER}" \
+      "trainer.grad_accum_iter=1" \
+      "checkpoint.save_iter=${SAVE_ITER}" \
+      "dataloader_train.batch_size.global_bsz=32" \
+      "dataloader_train.num_workers=1" \
+      "dataloader_train.prefetch_factor=1" \
+      "dataloader_train.persistent_workers=false" \
+      "dataloader_train.pin_memory=false" \
+      "dataloader_train.in_order=true" \
+      "model.config.offline_video_embedding_dir=" \
+      "model.config.offline_video_embedding_required=false" \
+      "model.config.offline_video_latent_dir=${GOAL_VIDEO_LATENT_DIR}" \
+      "model.config.offline_video_latent_required=true" \
+      "model.config.pipe_config.action_source_prior.enabled=true" \
+      "model.config.pipe_config.action_source_prior.mode=video_prior_sample" \
+      "model.config.pipe_config.action_conditioning.mode=zero_video"
+  ) >> "${log_path}" 2>&1 &
+  log "Fallback source-only launcher pid=$!"
+}
+
+monitor_source_condition() {
+  local source_done_at=0
+  while true; do
+    local ckpt_iter progress loss sleep_for remaining
+    ckpt_iter=$(latest_checkpoint_iter)
+    progress=$(latest_progress_step "${SOURCE_LOG}")
+    loss=$(latest_loss_line "${SOURCE_LOG}")
+    remaining=$(( MAX_ITER - progress ))
+    (( remaining < 0 )) && remaining=0
+
+    log "source+cond progress=${progress}/${MAX_ITER} ckpt=${ckpt_iter} ${loss}"
+
+    if (( ckpt_iter >= MAX_ITER )) && ! source_running; then
+      log "source+cond completed and process exited."
+      return 0
+    fi
+
+    if (( ckpt_iter >= MAX_ITER )) && source_running; then
+      log "source+cond reached final checkpoint; waiting for process exit."
+      sleep "${FINAL_SLEEP}"
+      continue
+    fi
+
+    if ! source_running; then
+      log "WARNING source+cond process is not running before final checkpoint; latest ckpt=${ckpt_iter}."
+      if (( source_done_at == 0 )); then
+        source_done_at=$(date +%s)
+      fi
+    fi
+
+    sleep_for="${NORMAL_SLEEP}"
+    if (( remaining <= FINAL_WINDOW )); then
+      sleep_for="${FINAL_SLEEP}"
+    fi
+    log "sleeping ${sleep_for}s before next source+cond check."
+    sleep "${sleep_for}"
+  done
+}
+
+ensure_source_only_started() {
+  local done_at now so_log
+  done_at=$(date +%s)
+  while true; do
+    so_log=$(latest_source_only_log)
+    if source_only_running || source_only_entered_training "${so_log}"; then
+      log "source-only detected. log=${so_log}"
+      return 0
+    fi
+
+    if continuation_watcher_running; then
+      now=$(date +%s)
+      if (( now - done_at < WATCHER_GRACE_SECONDS )); then
+        log "waiting for existing continuation watcher to start source-only. elapsed=$((now - done_at))s"
+        sleep "${FINAL_SLEEP}"
+        continue
+      fi
+      log "existing watcher has not started source-only after grace period; checking fallback."
+    fi
+
+    if ! source_only_running; then
+      launch_source_only_fallback
+    fi
+
+    sleep "${FINAL_SLEEP}"
+  done
+}
+
+monitor_source_only() {
+  local so_log progress loss sleep_for remaining
+  while true; do
+    so_log=$(latest_source_only_log)
+    progress=$(latest_progress_step "${so_log}")
+    loss=$(latest_loss_line "${so_log}")
+    remaining=$(( MAX_ITER - progress ))
+    (( remaining < 0 )) && remaining=0
+    log "source-only progress=${progress}/${MAX_ITER} ${loss} log=${so_log:-NA}"
+
+    if source_only_entered_training "${so_log}"; then
+      log "source-only training loop confirmed."
+    else
+      log "source-only not yet in training loop; sleeping ${FINAL_SLEEP}s."
+      sleep "${FINAL_SLEEP}"
+      continue
+    fi
+
+    if (( progress >= MAX_ITER )) && ! source_only_running; then
+      log "source-only appears complete. monitor exiting."
+      return 0
+    fi
+
+    sleep_for="${NORMAL_SLEEP}"
+    if (( remaining <= FINAL_WINDOW )); then
+      sleep_for="${FINAL_SLEEP}"
+    fi
+    log "sleeping ${sleep_for}s before next source-only check."
+    sleep "${sleep_for}"
+  done
+}
+
+main() {
+  log "monitor started pid=$$"
+  log "source=${SOURCE_GROUP}/${SOURCE_NAME}"
+  log "source_log=${SOURCE_LOG}"
+  log "goal_latent_dir=${GOAL_VIDEO_LATENT_DIR}"
+  monitor_source_condition
+  ensure_source_only_started
+  monitor_source_only
+}
+
+main "$@"

--- a/scripts/run_goal_precompute_then_train.sh
+++ b/scripts/run_goal_precompute_then_train.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+DATA_ROOT=${MIMIC_LIBERO_DATA_ROOT:-"${REPO_DIR}/data"}
+VIDEO_LATENT_ROOT=${MIMIC_LIBERO_VIDEO_LATENT_ROOT:-"${DATA_ROOT}/libero_video_latents"}
+GOAL_DATA_DIR=${MIMIC_LIBERO_GOAL_DIR:-"${DATA_ROOT}/libero_goal_full"}
+GOAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/libero_goal_full_v2w_libero_goal_tokenizer_latents"}
+
+GPUS=${GPUS:-0,1,2,3}
+NPROC_PER_NODE=${NPROC_PER_NODE:-4}
+PRECOMPUTE_MASTER_PORT=${PRECOMPUTE_MASTER_PORT:-29671}
+MASTER_PORT=${MASTER_PORT:-29631}
+PRECOMPUTE_BATCH_SIZE=${PRECOMPUTE_BATCH_SIZE:-8}
+PRECOMPUTE_NUM_WORKERS=${PRECOMPUTE_NUM_WORKERS:-1}
+PRECOMPUTE_PREFETCH_FACTOR=${PRECOMPUTE_PREFETCH_FACTOR:-1}
+
+MAX_ITER=${MAX_ITER:-50000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000000}
+DATALOADER_TRAIN_GLOBAL_BSZ=${DATALOADER_TRAIN_GLOBAL_BSZ:-32}
+DATALOADER_TRAIN_NUM_WORKERS=${DATALOADER_TRAIN_NUM_WORKERS:-1}
+DATALOADER_TRAIN_PREFETCH_FACTOR=${DATALOADER_TRAIN_PREFETCH_FACTOR:-1}
+DATALOADER_TRAIN_PERSISTENT_WORKERS=${DATALOADER_TRAIN_PERSISTENT_WORKERS:-false}
+DATALOADER_TRAIN_PIN_MEMORY=${DATALOADER_TRAIN_PIN_MEMORY:-false}
+DATALOADER_TRAIN_IN_ORDER=${DATALOADER_TRAIN_IN_ORDER:-true}
+
+mkdir -p "${VIDEO_LATENT_ROOT}"
+
+printf '[%s] goal tokenizer latent precompute starting\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'repo=%s\n' "${REPO_DIR}"
+printf 'goal_data_dir=%s\n' "${GOAL_DATA_DIR}"
+printf 'goal_video_latent_dir=%s\n' "${GOAL_VIDEO_LATENT_DIR}"
+printf 'gpus=%s nproc=%s precompute_batch_size=%s\n' "${GPUS}" "${NPROC_PER_NODE}" "${PRECOMPUTE_BATCH_SIZE}"
+
+cd "${REPO_DIR}"
+export CUDA_VISIBLE_DEVICES="${GPUS}"
+export PYTHONPATH="${REPO_DIR}/model:${PYTHONPATH:-}"
+
+"${PYTHON}" -m torch.distributed.run \
+  --nproc_per_node="${NPROC_PER_NODE}" \
+  --master_port="${PRECOMPUTE_MASTER_PORT}" \
+  tools/precompute_libero_video_latents.py \
+  --config libero_goal_full \
+  --data-dir "${GOAL_DATA_DIR}" \
+  --output-dir "${GOAL_VIDEO_LATENT_DIR}" \
+  --batch-size "${PRECOMPUTE_BATCH_SIZE}" \
+  --num-workers "${PRECOMPUTE_NUM_WORKERS}" \
+  --prefetch-factor "${PRECOMPUTE_PREFETCH_FACTOR}" \
+  --pin-memory \
+  --overwrite
+
+"${PYTHON}" - "${GOAL_VIDEO_LATENT_DIR}" <<'PYVERIFY'
+import json
+import pathlib
+import sys
+cache_dir = pathlib.Path(sys.argv[1])
+meta_path = cache_dir / "metadata.json"
+if not meta_path.exists():
+    raise SystemExit(f"missing metadata: {meta_path}")
+meta = json.loads(meta_path.read_text())
+latent_file = cache_dir / meta.get("latent_file", "video_latent.fp16.memmap")
+if not latent_file.exists():
+    raise SystemExit(f"missing latent memmap: {latent_file}")
+if int(meta["processed"]) != int(meta["cache_len"]):
+    raise SystemExit(f"incomplete cache: processed={meta['processed']} cache_len={meta['cache_len']}")
+print(f"verified tokenizer latent cache: processed={meta['processed']} cache_len={meta['cache_len']} world_size={meta.get('world_size')}")
+PYVERIFY
+
+printf '[%s] goal tokenizer latent precompute complete; starting goal training trio\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+export MIMIC_VIDEO_REPO_DIR="${REPO_DIR}"
+export MIMIC_VIDEO_PYTHON="${PYTHON}"
+export MIMIC_LIBERO_DATA_ROOT="${DATA_ROOT}"
+export MIMIC_LIBERO_VIDEO_LATENT_ROOT="${VIDEO_LATENT_ROOT}"
+export MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR="${GOAL_VIDEO_LATENT_DIR}"
+export USE_OFFLINE_VIDEO_EMBEDDINGS=false
+export USE_OFFLINE_VIDEO_LATENTS=true
+export SUITE_FILTER=goal
+export GPUS="${GPUS}"
+export NPROC_PER_NODE="${NPROC_PER_NODE}"
+export MASTER_PORT="${MASTER_PORT}"
+export MAX_ITER="${MAX_ITER}"
+export SAVE_ITER="${SAVE_ITER}"
+export LOGGING_ITER="${LOGGING_ITER}"
+export VALIDATION_ITER="${VALIDATION_ITER}"
+export DATALOADER_TRAIN_GLOBAL_BSZ="${DATALOADER_TRAIN_GLOBAL_BSZ}"
+export DATALOADER_TRAIN_NUM_WORKERS="${DATALOADER_TRAIN_NUM_WORKERS}"
+export DATALOADER_TRAIN_PREFETCH_FACTOR="${DATALOADER_TRAIN_PREFETCH_FACTOR}"
+export DATALOADER_TRAIN_PERSISTENT_WORKERS="${DATALOADER_TRAIN_PERSISTENT_WORKERS}"
+export DATALOADER_TRAIN_PIN_MEMORY="${DATALOADER_TRAIN_PIN_MEMORY}"
+export DATALOADER_TRAIN_IN_ORDER="${DATALOADER_TRAIN_IN_ORDER}"
+export DEBUG_STEP_TIMING=${DEBUG_STEP_TIMING:-1}
+export DEBUG_STEP_TIMING_INTERVAL=${DEBUG_STEP_TIMING_INTERVAL:-100}
+export DEBUG_W2A_TIMING=${DEBUG_W2A_TIMING:-1}
+export DEBUG_W2A_TIMING_INTERVAL=${DEBUG_W2A_TIMING_INTERVAL:-100}
+
+"${REPO_DIR}/scripts/train_libero_action_queue.sh" run
+
+printf '[%s] goal training trio complete\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/switch_goal_source_condition_to_shm_after_checkpoint.sh
+++ b/scripts/switch_goal_source_condition_to_shm_after_checkpoint.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+MODEL_DIR="${REPO_DIR}/model"
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+LOG_DIR="${RUN_ROOT}/logs"
+
+GPUS=${GPUS:-0,1,2,3}
+NPROC_PER_NODE=${NPROC_PER_NODE:-4}
+MASTER_PORT=${MASTER_PORT:-29653}
+MAX_ITER=${MAX_ITER:-50000}
+SWITCH_ITER=${SWITCH_ITER:-5000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000000}
+POLL_SECONDS=${POLL_SECONDS:-60}
+
+SOURCE_GROUP=${SOURCE_GROUP:-vlsp_source_condition}
+SOURCE_NAME=${SOURCE_NAME:-vlsp_source_condition_goal_20260629_183112}
+SOURCE_CKPT_DIR="${MODEL_DIR}/checkpoints/vam/${SOURCE_GROUP}/${SOURCE_NAME}/checkpoints"
+SOURCE_LATEST="${SOURCE_CKPT_DIR}/latest_checkpoint.txt"
+
+GOAL_DATA_CONFIG=${GOAL_DATA_CONFIG:-libero_goal_full_no_rgb}
+GOAL_EXP="w2a_${GOAL_DATA_CONFIG}_v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused_lr1.000e-04_layer20_bsz128"
+SHM_VIDEO_LATENT_DIR=${MIMIC_LIBERO_SHM_GOAL_VIDEO_LATENT_DIR:-/dev/shm/mimic_video_latents/libero_goal_full_v2w_libero_goal_tokenizer_latents}
+
+CONTINUATION_SCRIPT="${REPO_DIR}/scripts/continue_goal_after_source_condition.sh"
+CONTINUATION_PID_FILE="${RUN_ROOT}/goal_continuation_watcher.pid"
+
+mkdir -p "${LOG_DIR}"
+
+ts() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+log() {
+  echo "[$(ts)] $*"
+}
+
+latest_iter() {
+  if [[ ! -f "${SOURCE_LATEST}" ]]; then
+    echo 0
+    return
+  fi
+  local latest
+  latest=$(tr -d '[:space:]' < "${SOURCE_LATEST}")
+  if [[ "${latest}" =~ iter_0*([0-9]+)\.pt ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo 0
+  fi
+}
+
+source_running() {
+  pgrep -f "job.group=${SOURCE_GROUP}.*job.name=${SOURCE_NAME}" >/dev/null 2>&1 \
+    || pgrep -f "job.name=${SOURCE_NAME}.*job.group=${SOURCE_GROUP}" >/dev/null 2>&1
+}
+
+require_file() {
+  [[ -f "$1" ]] || { log "ERROR missing file: $1" >&2; exit 1; }
+}
+
+preflight() {
+  [[ -x "${PYTHON}" ]] || { log "ERROR Python is not executable: ${PYTHON}" >&2; exit 1; }
+  [[ -x "${CONTINUATION_SCRIPT}" ]] || chmod +x "${CONTINUATION_SCRIPT}"
+  require_file "${SHM_VIDEO_LATENT_DIR}/metadata.json"
+  require_file "${SHM_VIDEO_LATENT_DIR}/video_latent.fp16.memmap"
+}
+
+stop_continuation_watcher() {
+  if [[ ! -f "${CONTINUATION_PID_FILE}" ]]; then
+    return
+  fi
+  local pid
+  pid=$(tr -d '[:space:]' < "${CONTINUATION_PID_FILE}" || true)
+  if [[ -z "${pid}" ]] || ! kill -0 "${pid}" >/dev/null 2>&1; then
+    return
+  fi
+  log "Stopping continuation watcher pid=${pid}."
+  pkill -TERM -P "${pid}" >/dev/null 2>&1 || true
+  kill -TERM "${pid}" >/dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    kill -0 "${pid}" >/dev/null 2>&1 || return
+    sleep 1
+  done
+  log "Continuation watcher pid=${pid} did not exit after TERM; sending KILL."
+  pkill -KILL -P "${pid}" >/dev/null 2>&1 || true
+  kill -KILL "${pid}" >/dev/null 2>&1 || true
+}
+
+stop_source_training() {
+  log "Stopping current source+cond training."
+  pkill -TERM -f "job.group=${SOURCE_GROUP}.*job.name=${SOURCE_NAME}" >/dev/null 2>&1 || true
+  pkill -TERM -f "job.name=${SOURCE_NAME}.*job.group=${SOURCE_GROUP}" >/dev/null 2>&1 || true
+  for _ in $(seq 1 60); do
+    source_running || return
+    sleep 1
+  done
+  log "source+cond did not exit after TERM; sending KILL."
+  pkill -KILL -f "job.group=${SOURCE_GROUP}.*job.name=${SOURCE_NAME}" >/dev/null 2>&1 || true
+  pkill -KILL -f "job.name=${SOURCE_NAME}.*job.group=${SOURCE_GROUP}" >/dev/null 2>&1 || true
+}
+
+start_source_training_from_shm() {
+  local stamp log_path
+  stamp=$(date -u +%Y%m%d_%H%M%S)
+  log_path="${LOG_DIR}/main_source_condition_goal_resume32_shm_${stamp}.log"
+  log "Restarting source+cond from latest checkpoint with /dev/shm cache."
+  log "log=${log_path}"
+  (
+    cd "${MODEL_DIR}"
+    export CUDA_VISIBLE_DEVICES="${GPUS}"
+    export PYTHONPATH="${MODEL_DIR}:${PYTHONPATH:-}"
+    export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-7200}
+    export TORCH_NCCL_ASYNC_ERROR_HANDLING=${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}
+    export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+    export NVTE_FUSED_ATTN=${NVTE_FUSED_ATTN:-0}
+    export DEBUG_STEP_TIMING=0
+    export DEBUG_W2A_TIMING=0
+
+    "${PYTHON}" -m torch.distributed.run \
+      --nproc_per_node="${NPROC_PER_NODE}" \
+      --master_port="${MASTER_PORT}" \
+      -m scripts.train \
+      --config=cosmos_predict2/configs/config.py -- \
+      "experiment=${GOAL_EXP}" \
+      "job.group=${SOURCE_GROUP}" \
+      "job.name=${SOURCE_NAME}" \
+      "trainer.max_iter=${MAX_ITER}" \
+      "trainer.logging_iter=${LOGGING_ITER}" \
+      "trainer.validation_iter=${VALIDATION_ITER}" \
+      "trainer.grad_accum_iter=1" \
+      "checkpoint.save_iter=${SAVE_ITER}" \
+      "dataloader_train.batch_size.global_bsz=32" \
+      "dataloader_train.num_workers=1" \
+      "dataloader_train.prefetch_factor=1" \
+      "dataloader_train.persistent_workers=false" \
+      "dataloader_train.pin_memory=false" \
+      "dataloader_train.in_order=true" \
+      "model.config.offline_video_embedding_dir=" \
+      "model.config.offline_video_embedding_required=false" \
+      "model.config.offline_video_latent_dir=${SHM_VIDEO_LATENT_DIR}" \
+      "model.config.offline_video_latent_required=true" \
+      "model.config.pipe_config.action_source_prior.enabled=true" \
+      "model.config.pipe_config.action_source_prior.mode=video_prior_sample" \
+      "model.config.pipe_config.action_conditioning.mode=normal"
+  ) >"${log_path}" 2>&1 &
+  echo "$!" > "${RUN_ROOT}/source_condition_shm.pid"
+  log "source+cond shm pid=$(cat "${RUN_ROOT}/source_condition_shm.pid")"
+}
+
+start_continuation_watcher_from_shm() {
+  local stamp log_path
+  stamp=$(date -u +%Y%m%d_%H%M%S)
+  log_path="${LOG_DIR}/goal_continuation_watcher_shm_${stamp}.log"
+  log "Restarting continuation watcher with /dev/shm cache."
+  (
+    export MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR="${SHM_VIDEO_LATENT_DIR}"
+    export GPUS="${GPUS}"
+    export NPROC_PER_NODE="${NPROC_PER_NODE}"
+    export MASTER_PORT=29661
+    export MAX_ITER="${MAX_ITER}"
+    export SAVE_ITER="${SAVE_ITER}"
+    export LOGGING_ITER="${LOGGING_ITER}"
+    export VALIDATION_ITER="${VALIDATION_ITER}"
+    export POLL_SECONDS=300
+    exec "${CONTINUATION_SCRIPT}"
+  ) >"${log_path}" 2>&1 &
+  echo "$!" > "${CONTINUATION_PID_FILE}"
+  echo "${log_path}" > "${RUN_ROOT}/goal_continuation_watcher_latest_log.txt"
+  log "continuation watcher shm pid=$(cat "${CONTINUATION_PID_FILE}") log=${log_path}"
+}
+
+main() {
+  preflight
+  log "Waiting for ${SOURCE_GROUP}/${SOURCE_NAME} to reach checkpoint iter ${SWITCH_ITER}."
+  while true; do
+    local iter
+    iter=$(latest_iter)
+    if (( iter >= MAX_ITER )); then
+      log "Already at iter ${iter}; source+cond is complete, no switch needed."
+      return 0
+    fi
+    if (( iter >= SWITCH_ITER )); then
+      log "Found checkpoint iter ${iter}; switching source+cond to /dev/shm cache."
+      stop_continuation_watcher
+      stop_source_training
+      start_source_training_from_shm
+      start_continuation_watcher_from_shm
+      log "Switch complete."
+      return 0
+    fi
+    if ! source_running; then
+      log "ERROR source+cond is not running and latest checkpoint is only iter ${iter}." >&2
+      return 1
+    fi
+    log "latest checkpoint iter ${iter}; waiting ${POLL_SECONDS}s."
+    sleep "${POLL_SECONDS}"
+  done
+}
+
+main "$@"

--- a/scripts/train_libero_action_mig4_nccl.sh
+++ b/scripts/train_libero_action_mig4_nccl.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+MODEL_DIR="${REPO_DIR}/model"
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+DATA_ROOT=${MIMIC_LIBERO_DATA_ROOT:-"${REPO_DIR}/data"}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+LOG_DIR="${RUN_ROOT}/logs"
+LAUNCH_DIR="${RUN_ROOT}/launchers"
+
+SUITE=${SUITE:-goal}
+VARIANT=${VARIANT:-baseline_gaussian}
+JOB_PREFIX=${JOB_PREFIX:-"${VARIANT}_${SUITE}_mig4_nccl"}
+MAX_ITER=${MAX_ITER:-50000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000000}
+RUN_VALIDATION=${RUN_VALIDATION:-false}
+MASTER_PORT=${MASTER_PORT:-29675}
+DATALOADER_TRAIN_GLOBAL_BSZ=${DATALOADER_TRAIN_GLOBAL_BSZ:-16}
+DATALOADER_TRAIN_NUM_WORKERS=${DATALOADER_TRAIN_NUM_WORKERS:-1}
+DATALOADER_TRAIN_PREFETCH_FACTOR=${DATALOADER_TRAIN_PREFETCH_FACTOR:-1}
+DATALOADER_TRAIN_PERSISTENT_WORKERS=${DATALOADER_TRAIN_PERSISTENT_WORKERS:-false}
+DATALOADER_TRAIN_PIN_MEMORY=${DATALOADER_TRAIN_PIN_MEMORY:-false}
+DATALOADER_TRAIN_IN_ORDER=${DATALOADER_TRAIN_IN_ORDER:-true}
+USE_OFFLINE_VIDEO_EMBEDDINGS=${USE_OFFLINE_VIDEO_EMBEDDINGS:-false}
+USE_OFFLINE_VIDEO_LATENTS=${USE_OFFLINE_VIDEO_LATENTS:-true}
+VIDEO_EMBEDDING_ROOT=${MIMIC_LIBERO_VIDEO_EMBEDDING_ROOT:-"${DATA_ROOT}/libero_video_embeddings"}
+VIDEO_LATENT_ROOT=${MIMIC_LIBERO_VIDEO_LATENT_ROOT:-"${DATA_ROOT}/libero_video_latents"}
+
+MIGS=(
+  "${MIG0:-MIG-1a53acd0-03f0-5f5e-963c-dc4fa053bb92}"
+  "${MIG1:-MIG-bc0e4429-8bc2-505b-ae08-0db43b4beae2}"
+  "${MIG2:-MIG-00393e6d-8dc3-5e12-be9e-4081cdad9af4}"
+  "${MIG3:-MIG-260dab4f-0956-5c1d-8549-7e88490ef3a3}"
+)
+
+GOAL_DATA_CONFIG=${GOAL_DATA_CONFIG:-libero_goal_full_no_rgb}
+SPATIAL_DATA_CONFIG=${SPATIAL_DATA_CONFIG:-libero_spatial_full_no_rgb}
+OBJECT_DATA_CONFIG=${OBJECT_DATA_CONFIG:-libero_object_full_no_rgb}
+
+GOAL_EXP="w2a_${GOAL_DATA_CONFIG}_v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused_lr1.000e-04_layer20_bsz128"
+SPATIAL_EXP="w2a_${SPATIAL_DATA_CONFIG}_v2w_libero_spatial_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007540_fused_lr1.000e-04_layer20_bsz128"
+OBJECT_EXP="w2a_${OBJECT_DATA_CONFIG}_v2w_libero_object_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000008260_fused_lr1.000e-04_layer20_bsz128"
+
+GOAL_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_GOAL_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_layer20"}
+SPATIAL_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_SPATIAL_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${SPATIAL_DATA_CONFIG%_no_rgb}_v2w_libero_spatial_layer20"}
+OBJECT_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_OBJECT_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${OBJECT_DATA_CONFIG%_no_rgb}_v2w_libero_object_layer20"}
+
+GOAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_tokenizer_latents"}
+SPATIAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_SPATIAL_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${SPATIAL_DATA_CONFIG%_no_rgb}_v2w_libero_spatial_tokenizer_latents"}
+OBJECT_VIDEO_LATENT_DIR=${MIMIC_LIBERO_OBJECT_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${OBJECT_DATA_CONFIG%_no_rgb}_v2w_libero_object_tokenizer_latents"}
+
+mkdir -p "${LOG_DIR}" "${LAUNCH_DIR}"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_file() {
+  [[ -f "$1" ]] || die "required file is missing: $1"
+}
+
+require_cache_dir() {
+  local label=$1
+  local path=$2
+  local payload=$3
+  [[ -d "${path}" ]] || die "${label} cache dir does not exist: ${path}"
+  require_file "${path}/metadata.json"
+  require_file "${path}/${payload}"
+}
+
+select_suite() {
+  case "${SUITE}" in
+    goal)
+      EXPERIMENT="${GOAL_EXP}"
+      VIDEO_EMBEDDING_DIR="${GOAL_VIDEO_EMBEDDING_DIR}"
+      VIDEO_LATENT_DIR="${GOAL_VIDEO_LATENT_DIR}"
+      ;;
+    spatial)
+      EXPERIMENT="${SPATIAL_EXP}"
+      VIDEO_EMBEDDING_DIR="${SPATIAL_VIDEO_EMBEDDING_DIR}"
+      VIDEO_LATENT_DIR="${SPATIAL_VIDEO_LATENT_DIR}"
+      ;;
+    object)
+      EXPERIMENT="${OBJECT_EXP}"
+      VIDEO_EMBEDDING_DIR="${OBJECT_VIDEO_EMBEDDING_DIR}"
+      VIDEO_LATENT_DIR="${OBJECT_VIDEO_LATENT_DIR}"
+      ;;
+    *)
+      die "unknown SUITE=${SUITE}; expected goal, spatial, or object"
+      ;;
+  esac
+}
+
+select_variant() {
+  case "${VARIANT}" in
+    vlsp_source_condition|source_condition)
+      JOB_GROUP="vlsp_source_condition"
+      SOURCE_ENABLED=true
+      SOURCE_MODE=video_prior_sample
+      CONDITIONING_MODE=normal
+      ;;
+    vlsp_source_only|source_only)
+      JOB_GROUP="vlsp_source_only"
+      SOURCE_ENABLED=true
+      SOURCE_MODE=video_prior_sample
+      CONDITIONING_MODE=zero_video
+      ;;
+    baseline_gaussian|baseline)
+      JOB_GROUP="baseline_gaussian"
+      SOURCE_ENABLED=false
+      SOURCE_MODE=gaussian
+      CONDITIONING_MODE=normal
+      ;;
+    *)
+      die "unknown VARIANT=${VARIANT}; expected source_condition, source_only, or baseline"
+      ;;
+  esac
+}
+
+preflight() {
+  [[ -x "${PYTHON}" ]] || die "Python is not executable: ${PYTHON}"
+  require_file "${REPO_DIR}/checkpoints/video_backbone/tokenizer/tokenizer.pth"
+  require_file "${REPO_DIR}/checkpoints/text_encoder/t5-11b/pytorch_model.bin"
+
+  if is_true "${USE_OFFLINE_VIDEO_EMBEDDINGS}" && is_true "${USE_OFFLINE_VIDEO_LATENTS}"; then
+    die "USE_OFFLINE_VIDEO_EMBEDDINGS and USE_OFFLINE_VIDEO_LATENTS are mutually exclusive"
+  fi
+  if is_true "${USE_OFFLINE_VIDEO_EMBEDDINGS}"; then
+    require_cache_dir "${SUITE} video embedding" "${VIDEO_EMBEDDING_DIR}" "crossattn_emb.fp16.memmap"
+    OFFLINE_VIDEO_EMBEDDING_DIR="${VIDEO_EMBEDDING_DIR}"
+    OFFLINE_VIDEO_EMBEDDING_REQUIRED=true
+    OFFLINE_VIDEO_LATENT_DIR=""
+    OFFLINE_VIDEO_LATENT_REQUIRED=false
+  elif is_true "${USE_OFFLINE_VIDEO_LATENTS}"; then
+    require_cache_dir "${SUITE} video latent" "${VIDEO_LATENT_DIR}" "video_latent.fp16.memmap"
+    OFFLINE_VIDEO_EMBEDDING_DIR=""
+    OFFLINE_VIDEO_EMBEDDING_REQUIRED=false
+    OFFLINE_VIDEO_LATENT_DIR="${VIDEO_LATENT_DIR}"
+    OFFLINE_VIDEO_LATENT_REQUIRED=true
+  else
+    OFFLINE_VIDEO_EMBEDDING_DIR=""
+    OFFLINE_VIDEO_EMBEDDING_REQUIRED=false
+    OFFLINE_VIDEO_LATENT_DIR=""
+    OFFLINE_VIDEO_LATENT_REQUIRED=false
+  fi
+}
+
+select_suite
+select_variant
+preflight
+
+STAMP=$(date -u +%Y%m%d_%H%M%S)
+JOB_NAME="${JOB_PREFIX}_${STAMP}"
+RANK_PID_FILE="${LAUNCH_DIR}/${JOB_NAME}.ranks"
+DONE_FILE="${LAUNCH_DIR}/${JOB_NAME}.done"
+META_FILE="${LAUNCH_DIR}/${JOB_NAME}.meta"
+
+cat > "${META_FILE}" <<EOF
+JOB_NAME=${JOB_NAME}
+SUITE=${SUITE}
+VARIANT=${VARIANT}
+JOB_GROUP=${JOB_GROUP}
+EXPERIMENT=${EXPERIMENT}
+MODEL_DIR=${MODEL_DIR}
+PYTHON=${PYTHON}
+OFFLINE_VIDEO_EMBEDDING_DIR=${OFFLINE_VIDEO_EMBEDDING_DIR}
+OFFLINE_VIDEO_LATENT_DIR=${OFFLINE_VIDEO_LATENT_DIR}
+MIMIC_DISTRIBUTED_BACKEND=nccl
+NCCL_SHM_DISABLE=1
+NCCL_P2P_DISABLE=1
+NCCL_IB_DISABLE=1
+NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-eth0}
+PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+MAX_ITER=${MAX_ITER}
+DATALOADER_TRAIN_GLOBAL_BSZ=${DATALOADER_TRAIN_GLOBAL_BSZ}
+EOF
+
+COMMON_OPTS=(
+  --
+  "experiment=${EXPERIMENT}"
+  "job.group=${JOB_GROUP}"
+  "job.name=${JOB_NAME}"
+  "trainer.max_iter=${MAX_ITER}"
+  "trainer.logging_iter=${LOGGING_ITER}"
+  "trainer.validation_iter=${VALIDATION_ITER}"
+  "trainer.run_validation=${RUN_VALIDATION}"
+  "trainer.grad_accum_iter=1"
+  "checkpoint.save_iter=${SAVE_ITER}"
+  "dataloader_train.batch_size.global_bsz=${DATALOADER_TRAIN_GLOBAL_BSZ}"
+  "dataloader_train.num_workers=${DATALOADER_TRAIN_NUM_WORKERS}"
+  "dataloader_train.prefetch_factor=${DATALOADER_TRAIN_PREFETCH_FACTOR}"
+  "dataloader_train.persistent_workers=${DATALOADER_TRAIN_PERSISTENT_WORKERS}"
+  "dataloader_train.pin_memory=${DATALOADER_TRAIN_PIN_MEMORY}"
+  "dataloader_train.in_order=${DATALOADER_TRAIN_IN_ORDER}"
+  "model.config.offline_video_embedding_dir=${OFFLINE_VIDEO_EMBEDDING_DIR}"
+  "model.config.offline_video_embedding_required=${OFFLINE_VIDEO_EMBEDDING_REQUIRED}"
+  "model.config.offline_video_latent_dir=${OFFLINE_VIDEO_LATENT_DIR}"
+  "model.config.offline_video_latent_required=${OFFLINE_VIDEO_LATENT_REQUIRED}"
+  "model.config.pipe_config.action_source_prior.enabled=${SOURCE_ENABLED}"
+  "model.config.pipe_config.action_source_prior.mode=${SOURCE_MODE}"
+  "model.config.pipe_config.action_conditioning.mode=${CONDITIONING_MODE}"
+)
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) starting ${JOB_NAME}"
+: > "${RANK_PID_FILE}"
+pids=()
+for rank in 0 1 2 3; do
+  (
+    cd "${MODEL_DIR}"
+    export CUDA_VISIBLE_DEVICES="${MIGS[$rank]}"
+    export NVIDIA_VISIBLE_DEVICES="${MIGS[$rank]}"
+    export NCCL_MIG_ID="${MIGS[$rank]}"
+    export RANK="${rank}"
+    export LOCAL_RANK="${rank}"
+    export WORLD_SIZE=4
+    export LOCAL_WORLD_SIZE=4
+    export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+    export MASTER_PORT="${MASTER_PORT}"
+    export PYTHONPATH="${MODEL_DIR}:${PYTHONPATH:-}"
+    export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC="${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-7200}"
+    export TORCH_NCCL_ASYNC_ERROR_HANDLING="${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}"
+    export MIMIC_DISTRIBUTED_BACKEND=nccl
+    export NCCL_SHM_DISABLE="${NCCL_SHM_DISABLE:-1}"
+    export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-1}"
+    export NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
+    export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-eth0}"
+    export NCCL_CUMEM_HOST_ENABLE="${NCCL_CUMEM_HOST_ENABLE:-0}"
+    export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+    export NVTE_FUSED_ATTN="${NVTE_FUSED_ATTN:-0}"
+    export DEBUG_STEP_TIMING="${DEBUG_STEP_TIMING:-0}"
+    export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+    export DEBUG_W2A_TIMING="${DEBUG_W2A_TIMING:-0}"
+    "${PYTHON}" -m scripts.train --config cosmos_predict2/configs/config.py "${COMMON_OPTS[@]}"
+  ) > "${LOG_DIR}/${JOB_NAME}.rank${rank}.log" 2>&1 &
+  pid=$!
+  echo "rank${rank} pid=${pid} mig=${MIGS[$rank]} log=${LOG_DIR}/${JOB_NAME}.rank${rank}.log" | tee -a "${RANK_PID_FILE}"
+  pids+=("${pid}")
+done
+
+status=0
+for pid in "${pids[@]}"; do
+  if ! wait "${pid}"; then
+    status=1
+  fi
+done
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) JOB=${JOB_NAME} STATUS=${status}" | tee "${DONE_FILE}"
+exit "${status}"

--- a/scripts/train_libero_action_queue.sh
+++ b/scripts/train_libero_action_queue.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${MIMIC_VIDEO_REPO_DIR:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/Video-as-action-generation-source/mimic-video}
+MODEL_DIR="${REPO_DIR}/model"
+PYTHON=${MIMIC_VIDEO_PYTHON:-/XYFS02/HDD_POOL/nju_shklu/nju_shklu_1/mixture-of-horizon-for-world-action-model/mimic-video/model/.venv/bin/python}
+DATA_ROOT=${MIMIC_LIBERO_DATA_ROOT:-"${REPO_DIR}/data"}
+RUN_ROOT=${MIMIC_LIBERO_RUN_ROOT:-"${REPO_DIR}/runs/libero_action_queue"}
+LOG_DIR="${RUN_ROOT}/logs"
+STATE_FILE="${RUN_ROOT}/queue_state.tsv"
+
+GPUS=${GPUS:-0,1,2,3}
+NPROC_PER_NODE=${NPROC_PER_NODE:-4}
+MASTER_PORT=${MASTER_PORT:-29631}
+MAX_ITER=${MAX_ITER:-50000}
+SAVE_ITER=${SAVE_ITER:-1000}
+LOGGING_ITER=${LOGGING_ITER:-100}
+VALIDATION_ITER=${VALIDATION_ITER:-1000}
+RESUME=${RESUME:-0}
+SUITE_FILTER=${SUITE_FILTER:-}
+DATALOADER_TRAIN_GLOBAL_BSZ=${DATALOADER_TRAIN_GLOBAL_BSZ:-32}
+DATALOADER_TRAIN_NUM_WORKERS=${DATALOADER_TRAIN_NUM_WORKERS:-1}
+DATALOADER_TRAIN_PREFETCH_FACTOR=${DATALOADER_TRAIN_PREFETCH_FACTOR:-1}
+DATALOADER_TRAIN_PERSISTENT_WORKERS=${DATALOADER_TRAIN_PERSISTENT_WORKERS:-false}
+DATALOADER_TRAIN_PIN_MEMORY=${DATALOADER_TRAIN_PIN_MEMORY:-false}
+DATALOADER_TRAIN_IN_ORDER=${DATALOADER_TRAIN_IN_ORDER:-true}
+USE_OFFLINE_VIDEO_EMBEDDINGS=${USE_OFFLINE_VIDEO_EMBEDDINGS:-false}
+USE_OFFLINE_VIDEO_LATENTS=${USE_OFFLINE_VIDEO_LATENTS:-true}
+VIDEO_EMBEDDING_ROOT=${MIMIC_LIBERO_VIDEO_EMBEDDING_ROOT:-"${DATA_ROOT}/libero_video_embeddings"}
+VIDEO_LATENT_ROOT=${MIMIC_LIBERO_VIDEO_LATENT_ROOT:-"${DATA_ROOT}/libero_video_latents"}
+
+GOAL_DATA_CONFIG=${GOAL_DATA_CONFIG:-libero_goal_full_no_rgb}
+SPATIAL_DATA_CONFIG=${SPATIAL_DATA_CONFIG:-libero_spatial_full_no_rgb}
+OBJECT_DATA_CONFIG=${OBJECT_DATA_CONFIG:-libero_object_full_no_rgb}
+
+GOAL_DATA_DIR=${MIMIC_LIBERO_GOAL_DIR:-"${DATA_ROOT}/${GOAL_DATA_CONFIG%_no_rgb}"}
+SPATIAL_DATA_DIR=${MIMIC_LIBERO_SPATIAL_DIR:-"${DATA_ROOT}/${SPATIAL_DATA_CONFIG%_no_rgb}"}
+OBJECT_DATA_DIR=${MIMIC_LIBERO_OBJECT_DIR:-"${DATA_ROOT}/${OBJECT_DATA_CONFIG%_no_rgb}"}
+
+GOAL_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_GOAL_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_layer20"}
+SPATIAL_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_SPATIAL_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${SPATIAL_DATA_CONFIG%_no_rgb}_v2w_libero_spatial_layer20"}
+OBJECT_VIDEO_EMBEDDING_DIR=${MIMIC_LIBERO_OBJECT_VIDEO_EMBEDDING_DIR:-"${VIDEO_EMBEDDING_ROOT}/${OBJECT_DATA_CONFIG%_no_rgb}_v2w_libero_object_layer20"}
+
+GOAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_GOAL_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${GOAL_DATA_CONFIG%_no_rgb}_v2w_libero_goal_tokenizer_latents"}
+SPATIAL_VIDEO_LATENT_DIR=${MIMIC_LIBERO_SPATIAL_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${SPATIAL_DATA_CONFIG%_no_rgb}_v2w_libero_spatial_tokenizer_latents"}
+OBJECT_VIDEO_LATENT_DIR=${MIMIC_LIBERO_OBJECT_VIDEO_LATENT_DIR:-"${VIDEO_LATENT_ROOT}/${OBJECT_DATA_CONFIG%_no_rgb}_v2w_libero_object_tokenizer_latents"}
+
+GOAL_EXP="w2a_${GOAL_DATA_CONFIG}_v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused_lr1.000e-04_layer20_bsz128"
+SPATIAL_EXP="w2a_${SPATIAL_DATA_CONFIG}_v2w_libero_spatial_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007540_fused_lr1.000e-04_layer20_bsz128"
+OBJECT_EXP="w2a_${OBJECT_DATA_CONFIG}_v2w_libero_object_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000008260_fused_lr1.000e-04_layer20_bsz128"
+
+mkdir -p "${LOG_DIR}"
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+first_zarr() {
+  find -L "$1" -type d -name '*.zarr' -print -quit 2>/dev/null || true
+}
+
+require_dataset() {
+  local label=$1
+  local path=$2
+  [[ -d "${path}" ]] || die "${label} data_dir does not exist: ${path}"
+
+  local sample
+  sample=$(first_zarr "${path}")
+  [[ -n "${sample}" ]] || die "${label} data_dir has no .zarr episodes: ${path}"
+
+  [[ -e "${sample}/language_embedding/.zarray" ]] || die "${label} sample zarr is missing precomputed language_embedding: ${sample}"
+}
+
+require_file() {
+  [[ -f "$1" ]] || die "required file is missing: $1"
+}
+
+is_true() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_video_embedding_cache() {
+  local label=$1
+  local path=$2
+  [[ -d "${path}" ]] || die "${label} offline video embedding dir does not exist: ${path}"
+  require_file "${path}/metadata.json"
+  require_file "${path}/crossattn_emb.fp16.memmap"
+  require_file "${path}/video_sigma.npy"
+}
+
+require_video_latent_cache() {
+  local label=$1
+  local path=$2
+  [[ -d "${path}" ]] || die "${label} offline video latent dir does not exist: ${path}"
+  require_file "${path}/metadata.json"
+  require_file "${path}/video_latent.fp16.memmap"
+}
+
+preflight() {
+  [[ -x "${PYTHON}" ]] || die "Python is not executable: ${PYTHON}"
+  require_file "${REPO_DIR}/checkpoints/video_backbone/v2w_libero_goal_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007020_fused.pt"
+  require_file "${REPO_DIR}/checkpoints/video_backbone/v2w_libero_spatial_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000007540_fused.pt"
+  require_file "${REPO_DIR}/checkpoints/video_backbone/v2w_libero_object_agentview_lora_rank256_lr1.778e-04_bsz32_iter_000008260_fused.pt"
+  require_file "${REPO_DIR}/checkpoints/video_backbone/tokenizer/tokenizer.pth"
+  require_file "${REPO_DIR}/checkpoints/text_encoder/t5-11b/pytorch_model.bin"
+  require_dataset "goal (${GOAL_DATA_CONFIG})" "${GOAL_DATA_DIR}"
+  require_dataset "spatial (${SPATIAL_DATA_CONFIG})" "${SPATIAL_DATA_DIR}"
+  require_dataset "object (${OBJECT_DATA_CONFIG})" "${OBJECT_DATA_DIR}"
+}
+
+record_state() {
+  local status=$1
+  local variant=$2
+  local suite=$3
+  local job_name=$4
+  local log_path=$5
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${status}" "${variant}" "${suite}" "${job_name}" "${log_path}" >> "${STATE_FILE}"
+}
+
+run_one() {
+  local variant=$1
+  local suite=$2
+  local experiment=$3
+  local data_dir=$4
+  local video_embedding_dir=$5
+  local video_latent_dir=$6
+  local source_enabled=$7
+  local source_mode=$8
+  local conditioning_mode=$9
+
+  local offline_video_embedding_dir=""
+  local offline_video_embedding_required=false
+  local offline_video_latent_dir=""
+  local offline_video_latent_required=false
+  if is_true "${USE_OFFLINE_VIDEO_EMBEDDINGS}" && is_true "${USE_OFFLINE_VIDEO_LATENTS}"; then
+    die "USE_OFFLINE_VIDEO_EMBEDDINGS and USE_OFFLINE_VIDEO_LATENTS are mutually exclusive"
+  fi
+  if is_true "${USE_OFFLINE_VIDEO_EMBEDDINGS}"; then
+    offline_video_embedding_dir="${video_embedding_dir}"
+    offline_video_embedding_required=true
+    require_video_embedding_cache "${suite}" "${offline_video_embedding_dir}"
+  fi
+  if is_true "${USE_OFFLINE_VIDEO_LATENTS}"; then
+    offline_video_latent_dir="${video_latent_dir}"
+    offline_video_latent_required=true
+    require_video_latent_cache "${suite}" "${offline_video_latent_dir}"
+  fi
+
+  local stamp
+  stamp=$(date -u +%Y%m%d_%H%M%S)
+  local job_name="${variant}_${suite}_${stamp}"
+  local log_path="${LOG_DIR}/${job_name}.log"
+
+  record_state "START" "${variant}" "${suite}" "${job_name}" "${log_path}"
+  echo "=== START ${job_name} ===" | tee -a "${log_path}"
+  echo "experiment=${experiment}" | tee -a "${log_path}"
+  echo "data_dir=${data_dir}" | tee -a "${log_path}"
+  echo "offline_video_embedding_dir=${offline_video_embedding_dir}" | tee -a "${log_path}"
+  echo "offline_video_embedding_required=${offline_video_embedding_required}" | tee -a "${log_path}"
+  echo "offline_video_latent_dir=${offline_video_latent_dir}" | tee -a "${log_path}"
+  echo "offline_video_latent_required=${offline_video_latent_required}" | tee -a "${log_path}"
+  echo "dataloader_train.batch_size.global_bsz=${DATALOADER_TRAIN_GLOBAL_BSZ}" | tee -a "${log_path}"
+  echo "dataloader_train.num_workers=${DATALOADER_TRAIN_NUM_WORKERS}" | tee -a "${log_path}"
+  echo "dataloader_train.prefetch_factor=${DATALOADER_TRAIN_PREFETCH_FACTOR}" | tee -a "${log_path}"
+  echo "dataloader_train.persistent_workers=${DATALOADER_TRAIN_PERSISTENT_WORKERS}" | tee -a "${log_path}"
+  echo "dataloader_train.pin_memory=${DATALOADER_TRAIN_PIN_MEMORY}" | tee -a "${log_path}"
+  echo "dataloader_train.in_order=${DATALOADER_TRAIN_IN_ORDER}" | tee -a "${log_path}"
+
+  set +e
+  (
+    cd "${MODEL_DIR}"
+    export CUDA_VISIBLE_DEVICES="${GPUS}"
+    export PYTHONPATH="${MODEL_DIR}:${PYTHONPATH:-}"
+    export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-7200}
+    export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+    export NVTE_FUSED_ATTN=${NVTE_FUSED_ATTN:-0}
+    export NCCL_ASYNC_ERROR_HANDLING=${NCCL_ASYNC_ERROR_HANDLING:-1}
+
+    "${PYTHON}" -m torch.distributed.run \
+      --nproc_per_node="${NPROC_PER_NODE}" \
+      --master_port="${MASTER_PORT}" \
+      -m scripts.train \
+      --config=cosmos_predict2/configs/config.py -- \
+      "experiment=${experiment}" \
+      "job.group=${variant}" \
+      "job.name=${job_name}" \
+      "trainer.max_iter=${MAX_ITER}" \
+      "trainer.logging_iter=${LOGGING_ITER}" \
+      "trainer.validation_iter=${VALIDATION_ITER}" \
+      "checkpoint.save_iter=${SAVE_ITER}" \
+      "dataloader_train.batch_size.global_bsz=${DATALOADER_TRAIN_GLOBAL_BSZ}" \
+      "dataloader_train.num_workers=${DATALOADER_TRAIN_NUM_WORKERS}" \
+      "dataloader_train.prefetch_factor=${DATALOADER_TRAIN_PREFETCH_FACTOR}" \
+      "dataloader_train.persistent_workers=${DATALOADER_TRAIN_PERSISTENT_WORKERS}" \
+      "dataloader_train.pin_memory=${DATALOADER_TRAIN_PIN_MEMORY}" \
+      "dataloader_train.in_order=${DATALOADER_TRAIN_IN_ORDER}" \
+      "model.config.offline_video_embedding_dir=${offline_video_embedding_dir}" \
+      "model.config.offline_video_embedding_required=${offline_video_embedding_required}" \
+      "model.config.offline_video_latent_dir=${offline_video_latent_dir}" \
+      "model.config.offline_video_latent_required=${offline_video_latent_required}" \
+      "model.config.pipe_config.action_source_prior.enabled=${source_enabled}" \
+      "model.config.pipe_config.action_source_prior.mode=${source_mode}" \
+      "model.config.pipe_config.action_conditioning.mode=${conditioning_mode}"
+  ) 2>&1 | tee -a "${log_path}"
+  local train_status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "${train_status}" -ne 0 ]]; then
+    record_state "FAIL:${train_status}" "${variant}" "${suite}" "${job_name}" "${log_path}"
+    echo "=== FAIL ${job_name} status=${train_status} ===" | tee -a "${log_path}"
+    return "${train_status}"
+  fi
+
+  record_state "DONE" "${variant}" "${suite}" "${job_name}" "${log_path}"
+  echo "=== DONE ${job_name} ===" | tee -a "${log_path}"
+}
+
+already_done() {
+  local variant=$1
+  local suite=$2
+  [[ "${RESUME}" == "1" ]] || return 1
+  [[ -f "${STATE_FILE}" ]] || return 1
+  awk -F '\t' -v v="${variant}" -v s="${suite}" '$2 == "DONE" && $3 == v && $4 == s {found=1} END {exit !found}' "${STATE_FILE}"
+}
+
+run_queue() {
+  preflight
+  : > "${STATE_FILE}"
+
+  local variants=(
+    "vlsp_source_condition video_prior_sample normal true"
+    "vlsp_source_only video_prior_sample zero_video true"
+    "baseline_gaussian gaussian normal false"
+  )
+  local suites=(
+    "goal ${GOAL_EXP} ${GOAL_DATA_DIR} ${GOAL_VIDEO_EMBEDDING_DIR} ${GOAL_VIDEO_LATENT_DIR}"
+    "spatial ${SPATIAL_EXP} ${SPATIAL_DATA_DIR} ${SPATIAL_VIDEO_EMBEDDING_DIR} ${SPATIAL_VIDEO_LATENT_DIR}"
+    "object ${OBJECT_EXP} ${OBJECT_DATA_DIR} ${OBJECT_VIDEO_EMBEDDING_DIR} ${OBJECT_VIDEO_LATENT_DIR}"
+  )
+
+  for suite_spec in "${suites[@]}"; do
+    read -r suite experiment data_dir video_embedding_dir video_latent_dir <<< "${suite_spec}"
+    if [[ -n "${SUITE_FILTER}" && "${suite}" != "${SUITE_FILTER}" ]]; then
+      continue
+    fi
+    for variant_spec in "${variants[@]}"; do
+      read -r variant source_mode conditioning_mode source_enabled <<< "${variant_spec}"
+      if already_done "${variant}" "${suite}"; then
+        echo "skip completed ${variant}/${suite}"
+        continue
+      fi
+      run_one "${variant}" "${suite}" "${experiment}" "${data_dir}" "${video_embedding_dir}" "${video_latent_dir}" "${source_enabled}" "${source_mode}" "${conditioning_mode}"
+    done
+  done
+}
+
+case "${1:-run}" in
+  preflight)
+    preflight
+    echo "preflight ok"
+    ;;
+  run)
+    run_queue
+    ;;
+  *)
+    echo "usage: $0 [preflight|run]" >&2
+    exit 2
+    ;;
+esac

--- a/tools/benchmark_libero_dataloader.py
+++ b/tools/benchmark_libero_dataloader.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Benchmark the mimic-video LIBERO action dataloader without running the model."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def repo_paths() -> tuple[Path, Path]:
+    this = Path(__file__).resolve()
+    repo = this.parents[1]
+    model_dir = repo / 'model'
+    return repo, model_dir
+
+
+def summarize_batch(batch: Any, prefix: str = '') -> list[str]:
+    lines: list[str] = []
+    if isinstance(batch, dict):
+        for key in sorted(batch):
+            lines.extend(summarize_batch(batch[key], f'{prefix}{key}'))
+    elif torch.is_tensor(batch):
+        lines.append(f'{prefix}: shape={tuple(batch.shape)} dtype={batch.dtype}')
+    else:
+        shape = getattr(batch, 'shape', None)
+        dtype = getattr(batch, 'dtype', None)
+        lines.append(f'{prefix}: shape={tuple(shape) if shape is not None else None} dtype={dtype}')
+    return lines
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return float('nan')
+    values = sorted(values)
+    idx = min(len(values) - 1, max(0, round((pct / 100.0) * (len(values) - 1))))
+    return values[idx]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', required=True, help='Hydra dataloading config name, e.g. libero_goal_full')
+    parser.add_argument('--data-dir', type=Path, default=None, help='Override dataset.dataset.data_dir')
+    parser.add_argument('--batch-size', type=int, default=8, help='Local batch size for the benchmark')
+    parser.add_argument('--num-workers', type=int, default=0)
+    parser.add_argument('--prefetch-factor', type=int, default=None)
+    parser.add_argument('--persistent-workers', action='store_true')
+    parser.add_argument('--pin-memory', action='store_true')
+    parser.add_argument('--num-warmup', type=int, default=10)
+    parser.add_argument('--num-steps', type=int, default=100)
+    args = parser.parse_args()
+
+    _repo, model_dir = repo_paths()
+    sys.path.insert(0, str(model_dir))
+
+    from cosmos_predict2.configs.defaults.data_action import get_data_config, get_dataset
+    from torch.utils.data import DataLoader
+
+    cfg = get_data_config(args.config)
+    if args.data_dir is not None:
+        cfg.dataset.dataset.data_dir = str(args.data_dir)
+
+    dataset = get_dataset(cfg, is_train=True)
+    loader_kwargs = dict(
+        dataset=dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        drop_last=True,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+    )
+    if args.num_workers > 0:
+        loader_kwargs['persistent_workers'] = args.persistent_workers
+        loader_kwargs['prefetch_factor'] = args.prefetch_factor
+    loader = DataLoader(**loader_kwargs)
+
+    times: list[float] = []
+    total_samples = 0
+    first_batch = None
+    it = iter(loader)
+    total_iters = args.num_warmup + args.num_steps
+    for i in range(total_iters):
+        t0 = time.perf_counter()
+        try:
+            batch = next(it)
+        except StopIteration:
+            it = iter(loader)
+            batch = next(it)
+        dt = time.perf_counter() - t0
+        if i >= args.num_warmup:
+            times.append(dt)
+            if isinstance(batch, dict):
+                first_tensor = next((v for v in batch.values() if torch.is_tensor(v)), None)
+                if first_tensor is not None:
+                    total_samples += int(first_tensor.shape[0])
+            if first_batch is None:
+                first_batch = batch
+
+    total_time = sum(times)
+    print(f'config: {args.config}')
+    print(f'data_dir: {cfg.dataset.dataset.data_dir}')
+    print(f'dataset_len: {len(dataset)}')
+    print(f'batch_size: {args.batch_size}')
+    print(f'num_workers: {args.num_workers}')
+    print(f'prefetch_factor: {args.prefetch_factor}')
+    print(f'persistent_workers: {args.persistent_workers}')
+    print(f'pin_memory: {args.pin_memory}')
+    print(f'avg_data_time: {statistics.mean(times):.6f}')
+    print(f'p50_data_time: {percentile(times, 50):.6f}')
+    print(f'p90_data_time: {percentile(times, 90):.6f}')
+    print(f'p99_data_time: {percentile(times, 99):.6f}')
+    print(f'max_data_time: {max(times):.6f}')
+    print(f'samples_per_second: {total_samples / total_time if total_time > 0 else float("nan"):.3f}')
+    if isinstance(first_batch, dict):
+        print('keys_in_batch:')
+        for key in sorted(first_batch):
+            print(f'  {key}')
+    print('tensor_shapes:')
+    for line in summarize_batch(first_batch):
+        print(f'  {line}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/debug_inspect_libero_safetensors.py
+++ b/tools/debug_inspect_libero_safetensors.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Inspect LIBERO action samples stored as .safetensors or .zarr episodes.
+
+The current mimic-video LIBERO action pipeline stores converted data as one
+.zarr directory per episode. This script also supports .safetensors because some
+precomputed embedding pipelines use that format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+from pathlib import Path
+from typing import Iterable
+
+
+def iter_samples(data_dir: Path) -> Iterable[Path]:
+    yield from data_dir.rglob('*.safetensors')
+    yield from data_dir.rglob('*.zarr')
+
+
+def describe_value(name: str, value) -> None:
+    shape = getattr(value, 'shape', None)
+    dtype = getattr(value, 'dtype', None)
+    print(f'  key: {name}')
+    print(f'    shape: {tuple(shape) if shape is not None else None}')
+    print(f'    dtype: {dtype}')
+
+
+def inspect_safetensors(path: Path) -> None:
+    try:
+        from safetensors import safe_open
+    except ImportError as exc:
+        raise SystemExit('safetensors is not installed in this environment') from exc
+
+    print(f'file: {path}')
+    with safe_open(str(path), framework='pt', device='cpu') as f:
+        for key in sorted(f.keys()):
+            tensor = f.get_tensor(key)
+            describe_value(key, tensor)
+
+
+def inspect_zarr(path: Path) -> None:
+    try:
+        import zarr
+    except ImportError as exc:
+        raise SystemExit('zarr is not installed in this environment') from exc
+
+    print(f'file: {path}')
+    root = zarr.open(str(path), mode='r')
+
+    def walk(group, prefix: str = '') -> None:
+        for key in sorted(group.keys()):
+            value = group[key]
+            name = f'{prefix}/{key}' if prefix else key
+            if hasattr(value, 'shape'):
+                describe_value(name, value)
+            else:
+                walk(value, name)
+
+    walk(root)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data-dir', type=Path, required=True)
+    parser.add_argument('--num-files', type=int, default=3)
+    args = parser.parse_args()
+
+    paths = list(itertools.islice(iter_samples(args.data_dir), args.num_files))
+    if not paths:
+        raise SystemExit(f'No .safetensors or .zarr samples found under {args.data_dir}')
+
+    for path in paths:
+        if path.suffix == '.safetensors':
+            inspect_safetensors(path)
+        elif path.suffix == '.zarr':
+            inspect_zarr(path)
+        else:
+            continue
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/precompute_libero_video_embeddings.py
+++ b/tools/precompute_libero_video_embeddings.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Precompute LIBERO world2action video conditioning embeddings.
+
+This writes the frozen video2world hidden state used by the action decoder's
+cross-attention to a memory-mapped fp16 cache. The cache is indexed by the
+MimicDataset sample_idx, which is the same global chunk index consumed by the
+training sampler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from einops import rearrange
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+
+def repo_paths() -> tuple[Path, Path]:
+    this = Path(__file__).resolve()
+    repo = this.parents[1]
+    model_dir = repo / "model"
+    return repo, model_dir
+
+
+def move_to_cuda(value: Any) -> Any:
+    if torch.is_tensor(value):
+        return value.to(device="cuda", non_blocking=True)
+    if isinstance(value, dict):
+        return {k: move_to_cuda(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [move_to_cuda(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(move_to_cuda(v) for v in value)
+    return value
+
+
+def draw_video_sigma(pipe, batch_size: int, *, is_video_batch: bool) -> torch.Tensor:
+    sigma_B = pipe.scheduler.sample_sigma(batch_size)
+    sigma_B_1 = rearrange(sigma_B, "b -> b 1")
+    multiplier = math.sqrt(pipe.config.state_t) if pipe.config.adjust_video_noise and is_video_batch else 1.0
+    sigma_B_1 = sigma_B_1 * multiplier
+    if is_video_batch:
+        log_200 = math.log(200)
+        log_100000 = math.log(100000)
+        mask = torch.rand(sigma_B_1.shape, device=sigma_B_1.device) < 0.05
+        log_new_sigma = torch.rand(sigma_B_1.shape, device=sigma_B_1.device).type_as(sigma_B_1) * (
+            log_100000 - log_200
+        ) + log_200
+        sigma_B_1 = torch.where(mask, log_new_sigma.exp(), sigma_B_1)
+    return sigma_B_1
+
+
+@torch.inference_mode()
+def compute_embeddings(pipe, batch: dict[str, torch.Tensor], xattn_layer_idx: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    sample_idx = batch["sample_idx"].detach().cpu().numpy().astype(np.int64, copy=False).reshape(-1)
+    batch_cuda = move_to_cuda(batch)
+    _, video_B_C_T_H_W, condition = pipe.get_mimic_data_and_condition(batch_cuda)
+    video_sigma_B_1 = draw_video_sigma(pipe, video_B_C_T_H_W.shape[0], is_video_batch=condition.is_video)
+    video_epsilon_B_C_T_H_W = torch.randn(video_B_C_T_H_W.size(), device="cuda", dtype=pipe.precision)
+    world_pred = pipe.denoise(
+        video_B_C_T_H_W + video_epsilon_B_C_T_H_W * rearrange(video_sigma_B_1, "b t -> b 1 t 1 1"),
+        video_sigma_B_1,
+        condition,
+        use_cuda_graphs=False,
+        return_only_hidden_states_up_to=xattn_layer_idx,
+        return_decoded_video=False,
+    )
+    crossattn = world_pred.hidden_states[xattn_layer_idx]
+    B, T, H, W, D = crossattn.shape
+    crossattn = crossattn.reshape(B, T * H * W, D)
+    return (
+        sample_idx,
+        crossattn.detach().to(dtype=torch.float16, device="cpu").numpy(),
+        video_sigma_B_1.detach().to(dtype=torch.float32, device="cpu").numpy(),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, help="LIBERO dataloading config, e.g. libero_goal_full")
+    parser.add_argument("--data-dir", type=Path, default=None, help="Override dataset.dataset.data_dir")
+    parser.add_argument("--video-dit-path", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--xattn-layer-idx", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--prefetch-factor", type=int, default=1)
+    parser.add_argument("--pin-memory", action="store_true")
+    parser.add_argument("--max-samples", type=int, default=None, help="Debug only: precompute the first N samples")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    repo, model_dir = repo_paths()
+    sys.path.insert(0, str(model_dir))
+
+    from cosmos_predict2.configs.config_video2world import get_cosmos_predict2_video2world_pipeline
+    from cosmos_predict2.configs.defaults.data_action import get_data_config, get_dataset
+    from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
+
+    if args.output_dir.exists():
+        if not args.overwrite:
+            raise SystemExit(f"output dir already exists; pass --overwrite to replace: {args.output_dir}")
+        shutil.rmtree(args.output_dir)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    cfg = get_data_config(args.config)
+    if args.data_dir is not None:
+        cfg.dataset.dataset.data_dir = str(args.data_dir)
+    dataset = get_dataset(cfg, is_train=True)
+    cache_len = len(dataset) if args.max_samples is None else min(len(dataset), args.max_samples)
+    if cache_len <= 0:
+        raise SystemExit("empty dataset/cache length")
+
+    loader_kwargs = dict(
+        dataset=dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        drop_last=False,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+    )
+    if args.num_workers > 0:
+        loader_kwargs["prefetch_factor"] = args.prefetch_factor
+        loader_kwargs["persistent_workers"] = True
+    loader = DataLoader(**loader_kwargs)
+
+    pipe_cfg = copy.deepcopy(get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="480", fps=10))
+    pipe_cfg.guardrail_config.enabled = False
+    pipe = Video2WorldPipeline.from_config(
+        pipe_cfg,
+        dit_path=str(args.video_dit_path),
+        use_text_encoder=False,
+        device="cuda",
+        torch_dtype=torch.bfloat16,
+    )
+    pipe.requires_grad_(False)
+    pipe.eval()
+
+    crossattn_mmap = None
+    sigma_mmap = None
+    crossattn_shape = None
+    processed = 0
+    t0 = time.perf_counter()
+
+    pbar = tqdm(total=cache_len, desc="precomputing video embeddings")
+    for batch in loader:
+        sample_idx, crossattn_np, sigma_np = compute_embeddings(pipe, batch, args.xattn_layer_idx)
+        keep = sample_idx < cache_len
+        if not np.any(keep):
+            break
+        sample_idx = sample_idx[keep]
+        crossattn_np = crossattn_np[keep]
+        sigma_np = sigma_np[keep]
+
+        if crossattn_mmap is None:
+            num_tokens, dim = crossattn_np.shape[1:]
+            crossattn_shape = (cache_len, num_tokens, dim)
+            est_gb = np.prod(crossattn_shape) * np.dtype(np.float16).itemsize / 1e9
+            print(f"dataset_len: {len(dataset)}")
+            print(f"cache_len: {cache_len}")
+            print(f"crossattn_shape: {crossattn_shape}")
+            print(f"estimated_crossattn_size_gb: {est_gb:.2f}")
+            crossattn_mmap = np.memmap(
+                args.output_dir / "crossattn_emb.fp16.memmap",
+                dtype=np.float16,
+                mode="w+",
+                shape=crossattn_shape,
+            )
+            sigma_mmap = np.lib.format.open_memmap(
+                args.output_dir / "video_sigma.npy",
+                dtype=np.float32,
+                mode="w+",
+                shape=(cache_len, 1),
+            )
+
+        crossattn_mmap[sample_idx] = crossattn_np
+        sigma_mmap[sample_idx] = sigma_np
+        processed += len(sample_idx)
+        pbar.update(len(sample_idx))
+        if processed >= cache_len:
+            break
+    pbar.close()
+
+    if crossattn_mmap is None or sigma_mmap is None or crossattn_shape is None:
+        raise SystemExit("no embeddings were computed")
+    crossattn_mmap.flush()
+    sigma_mmap.flush()
+
+    metadata = {
+        "format_version": 1,
+        "repo": str(repo),
+        "data_config": args.config,
+        "data_dir": str(cfg.dataset.dataset.data_dir),
+        "dataset_len": len(dataset),
+        "cache_len": cache_len,
+        "processed": processed,
+        "xattn_layer_idx": args.xattn_layer_idx,
+        "video_dit_path": str(args.video_dit_path),
+        "crossattn_file": "crossattn_emb.fp16.memmap",
+        "crossattn_dtype": "float16",
+        "crossattn_shape": list(crossattn_shape),
+        "video_sigma_file": "video_sigma.npy",
+        "seed": args.seed,
+        "elapsed_sec": time.perf_counter() - t0,
+    }
+    with (args.output_dir / "metadata.json").open("w") as f:
+        json.dump(metadata, f, indent=2)
+    print(json.dumps(metadata, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/precompute_libero_video_latents.py
+++ b/tools/precompute_libero_video_latents.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Precompute LIBERO video tokenizer latents for world2action training.
+
+The cache is indexed by MimicDataset sample_idx. It stores the frozen Cosmos
+video tokenizer output used by Video2WorldPipeline.get_mimic_data_and_condition,
+so training can skip RGB zarr reads and tokenizer.encode while still sampling a
+fresh video sigma/epsilon and running the frozen video DiT online.
+
+The script can also be launched with torchrun. In that mode each rank owns a
+non-overlapping sample_idx shard and writes to disjoint rows of the same memmap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+
+def repo_paths() -> tuple[Path, Path]:
+    this = Path(__file__).resolve()
+    repo = this.parents[1]
+    return repo, repo / "model"
+
+
+def move_to_cuda(value: Any) -> Any:
+    if torch.is_tensor(value):
+        return value.to(device="cuda", non_blocking=True)
+    if isinstance(value, dict):
+        return {k: move_to_cuda(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [move_to_cuda(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(move_to_cuda(v) for v in value)
+    return value
+
+
+def encode_mimic_latent(tokenizer, batch: dict[str, torch.Tensor], *, sigma_data: float) -> tuple[np.ndarray, np.ndarray]:
+    sample_idx = batch["sample_idx"].detach().cpu().numpy().astype(np.int64, copy=False).reshape(-1)
+    obs_rgb = move_to_cuda(batch["obs/workspace_rgb"])
+    action_rgb = move_to_cuda(batch["action/workspace_rgb"])
+    raw_state = torch.concat((obs_rgb, action_rgb), dim=2)
+    latent = tokenizer.encode(raw_state) * sigma_data
+    if latent.shape[2] != 16:
+        padded = torch.zeros((latent.shape[0], 16, 16, 60, 80), device=latent.device, dtype=latent.dtype)
+        padded[:, :, : latent.shape[2], :, :] = latent
+        latent = padded
+    return sample_idx, latent.detach().to(dtype=torch.float16, device="cpu").numpy()
+
+
+def init_distributed_from_env() -> tuple[int, int, int]:
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    rank = int(os.environ.get("RANK", "0"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size > 1:
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(backend="nccl")
+    elif torch.cuda.is_available():
+        torch.cuda.set_device(0)
+    return rank, world_size, local_rank
+
+
+def barrier(world_size: int) -> None:
+    if world_size > 1:
+        dist.barrier()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, help="RGB LIBERO dataloading config, e.g. libero_goal_full")
+    parser.add_argument("--data-dir", type=Path, default=None, help="Override dataset.dataset.data_dir")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--prefetch-factor", type=int, default=1)
+    parser.add_argument("--pin-memory", action="store_true")
+    parser.add_argument("--max-samples", type=int, default=None, help="Debug only: precompute the first N samples")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    rank, world_size, local_rank = init_distributed_from_env()
+    is_rank0 = rank == 0
+
+    repo, model_dir = repo_paths()
+    sys.path.insert(0, str(model_dir))
+
+    from cosmos_predict2.configs.config_video2world import get_cosmos_predict2_video2world_pipeline
+    from cosmos_predict2.configs.defaults.data_action import get_data_config, get_dataset
+    from imaginaire.lazy_config import instantiate
+
+    if is_rank0:
+        if args.output_dir.exists():
+            if not args.overwrite:
+                raise SystemExit(f"output dir already exists; pass --overwrite to replace: {args.output_dir}")
+            shutil.rmtree(args.output_dir)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+    barrier(world_size)
+
+    cfg = get_data_config(args.config)
+    if args.data_dir is not None:
+        cfg.dataset.dataset.data_dir = str(args.data_dir)
+    dataset = get_dataset(cfg, is_train=True)
+    cache_len = len(dataset) if args.max_samples is None else min(len(dataset), args.max_samples)
+    if cache_len <= 0:
+        raise SystemExit("empty dataset/cache length")
+
+    shard_indices = list(range(rank, cache_len, world_size))
+    shard_dataset = torch.utils.data.Subset(dataset, shard_indices)
+    print(
+        f"rank={rank} local_rank={local_rank} world_size={world_size} "
+        f"shard_samples={len(shard_indices)} cache_len={cache_len}",
+        flush=True,
+    )
+
+    loader_kwargs = dict(
+        dataset=shard_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        drop_last=False,
+        num_workers=args.num_workers,
+        pin_memory=args.pin_memory,
+    )
+    if args.num_workers > 0:
+        loader_kwargs["prefetch_factor"] = args.prefetch_factor
+        loader_kwargs["persistent_workers"] = True
+    loader = DataLoader(**loader_kwargs)
+
+    pipe_cfg = copy.deepcopy(get_cosmos_predict2_video2world_pipeline(model_size="2B", resolution="480", fps=10))
+    tokenizer = instantiate(pipe_cfg.tokenizer)
+    tokenizer.to(device="cuda", dtype=torch.bfloat16)
+
+    latent_shape = (cache_len, 16, 16, 60, 80)
+    est_gb = np.prod(latent_shape) * np.dtype(np.float16).itemsize / 1e9
+    if is_rank0:
+        print(f"dataset_len: {len(dataset)}")
+        print(f"cache_len: {cache_len}")
+        print(f"latent_shape: {latent_shape}")
+        print(f"estimated_latent_size_gb: {est_gb:.2f}")
+        print(f"world_size: {world_size}")
+        np.memmap(
+            args.output_dir / "video_latent.fp16.memmap",
+            dtype=np.float16,
+            mode="w+",
+            shape=latent_shape,
+        ).flush()
+    barrier(world_size)
+
+    latent_mmap = np.memmap(
+        args.output_dir / "video_latent.fp16.memmap",
+        dtype=np.float16,
+        mode="r+",
+        shape=latent_shape,
+    )
+
+    processed = 0
+    t0 = time.perf_counter()
+    num_latent_conditional_frames = int(tokenizer.get_latent_num_frames(5))
+
+    pbar = tqdm(
+        total=len(shard_indices),
+        desc=f"precomputing video tokenizer latents rank {rank}/{world_size}",
+        disable=world_size > 1 and not is_rank0,
+    )
+    with torch.inference_mode():
+        for batch in loader:
+            sample_idx, latent_np = encode_mimic_latent(tokenizer, batch, sigma_data=pipe_cfg.sigma_data)
+            keep = sample_idx < cache_len
+            if not np.any(keep):
+                continue
+            sample_idx = sample_idx[keep]
+            latent_np = latent_np[keep]
+
+            latent_mmap[sample_idx] = latent_np
+            processed += len(sample_idx)
+            pbar.update(len(sample_idx))
+            if processed >= len(shard_indices):
+                break
+    pbar.close()
+    latent_mmap.flush()
+    barrier(world_size)
+
+    total_processed = processed
+    if world_size > 1:
+        processed_tensor = torch.tensor([processed], device="cuda", dtype=torch.long)
+        dist.all_reduce(processed_tensor, op=dist.ReduceOp.SUM)
+        total_processed = int(processed_tensor.item())
+
+    if is_rank0:
+        metadata = {
+            "format_version": 1,
+            "repo": str(repo),
+            "data_config": args.config,
+            "data_dir": str(cfg.dataset.dataset.data_dir),
+            "dataset_len": len(dataset),
+            "cache_len": cache_len,
+            "processed": total_processed,
+            "world_size": world_size,
+            "latent_file": "video_latent.fp16.memmap",
+            "latent_dtype": "float16",
+            "latent_shape": list(latent_shape),
+            "sigma_data": float(pipe_cfg.sigma_data),
+            "obs_pixel_frames": 5,
+            "total_pixel_frames": 61,
+            "num_latent_conditional_frames": num_latent_conditional_frames,
+            "elapsed_sec": time.perf_counter() - t0,
+        }
+        with (args.output_dir / "metadata.json").open("w") as f:
+            json.dump(metadata, f, indent=2, sort_keys=True)
+
+        print(f"processed: {total_processed}")
+        print(f"elapsed_sec: {metadata['elapsed_sec']:.2f}")
+        print(f"output_dir: {args.output_dir}")
+    barrier(world_size)
+    if world_size > 1:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Use the partially-denoised video latent to define the *source* endpoint of the action flow-matching sampler (x_t = (1-t)a + t s), in addition to its existing role as the action-DiT cross-attention condition.

New module `action_source_prior.py` implements a configurable source interface:
- modes: gaussian (baseline), video_prior_{sample,mean,residual,blend,dropout}, shuffled_video_prior, gt_action_noisy_debug
- horizon-aware diagonal-Gaussian prior with mean/attention/perceiver pooling
- independent action-conditioning (normal/zero_video/shuffled_video/dropout_video)
- optional KL / mean-L2 / std regularizers

Wiring: World2ActionPipeline.sample_action_source / prepare_action_condition, World2ActionModel loss + optimizer + checkpoint (source_prior.* / _ema) + metrics, config dataclasses, 14 registered VLSP experiments, smoke test, VLSP.md.

Baseline preservation is bit-identical when disabled (verified for the training epsilon draw and the inference arch_invariant_rand draw); old checkpoints load.